### PR TITLE
Schedule adjustments triggered by presenter unavailability

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ DO NOT WAIT UNTIL THE DAY OF THE WORKSHOP.
 |9:00 - 9:15 | [Intro to Astropy and Code of Conduct](01-IntroCoC) | Erik Tollerud |
 |9:15 - 10:00   | [Introduction to Python](02-PythonIntro) | Ellianna Schwab Abrahams |
 |*9:50* | *Last call on breakfast* | |
-|10:00 - 10:30  | [Astropy Units, Quantities, and Constants](03-UnitsQuantities) | Miguel de Val Borro |
+|10:00 - 10:30  | [Astropy Units, Quantities, and Constants](03-UnitsQuantities) | David Shupe |
 |**10:30 - 10:45**  |  **BREAK** | *Coffee provided*  |
 |10:45 - 11:15 | [Coordinates](04-Coordinates) | Erik Tollerud |
 |11:15 - 12:15 | [I/O: FITS and ASCII](05-FITS) | Lia Corrales |
 |**12:15 - 1:15**| **LUNCH** | *On your own* |
-|1:15 - 1:30 | [Astropy Tables](06-Tables)| Miguel de Val Borro  |
-|1:30 - 2:00 | [Models](07-Models) | Megan Sosey |
-|2:00 - 2:45 | [WCS and Images](08-WCS) | David Shupe |
+|1:15 - 1:45 | [Astropy Tables](06-Tables)| Erik Tollerud |
+|1:45 - 2:15 | [Models](07-Models) | Megan Sosey |
+|2:15 - 2:45 | [WCS and Images](08-WCS) | David Shupe |
 **2:45 - 3:15** | **BREAK** | *Snacks Provided* |
 |3:15 - 4:00 | [Photutils](09-Photutils) | Larry Bradley|
 |*3:20* | *Last call on snacks* | |


### PR DESCRIPTION
* Change presenter for Quantities, Units, Constants to David Shupe
* Change presenter for Astropy Tables to Erik Tollerud
* Increase Tables duration from 15 to 30 minutes
* Decrease WCS duration from 45 minutes to 30 minutes