### PR TITLE
Clarify some of the language in the final exercises of the WCS tutorial.

### DIFF
--- a/08-WCS/WCS_tutorial.ipynb
+++ b/08-WCS/WCS_tutorial.ipynb
@@ -252,11 +252,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Exercise 1:\n",
+    "### Exercise 1:\n",
     "\n",
     "- Create a WCS object from the file. \n",
     "\n",
-    "dist_file_name = 'dist_lookup.fits.gz'\n",
+    "`dist_file_name = 'data/dist_lookup.fits.gz'`\n",
     "\n",
     "This file contains all distortions typical for HST imaging data - SIP, lookup_table and det2im (detector to image - correcting detector irregularities). The lookup table and det2im distortions are stored in separate extensions so you will need to pass as a second argument to `wcs.WCS` the file object (already opened with astropy.io.fits).\n",
     "\n",
@@ -269,7 +269,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Exercise 2:\n",
+    "### Exercise 2:\n",
     "\n",
     "The FITS WCS standard supports alternate WCSs in the same eader.\n",
     "These are defined by the same keywords with a character (A...Z) appended\n",
@@ -285,10 +285,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "\n",
-    "f = fits.open(\"data/dist_lookup.fits.gz\")"
+    "dist_file_name = 'data/dist_lookup.fits.gz'\n",
+    "f = fits.open(dist_file_name)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -308,7 +314,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Just some clarifications to the language in the WCS tutorial exercises, specifically, it was giving different paths in the markdown than in the python cell.  The markdown was referring to a non-existent file.