### PR TITLE
Clarify how imexam works 

### DIFF
--- a/00-Install_and_Setup/check_env.py
+++ b/00-Install_and_Setup/check_env.py
@@ -46,7 +46,6 @@ pkgs = {'IPython': '7.2',
         'skimage': '0.14',
         'pandas': '0.23',
         'astroquery': '0.3',
-        'imexam': '0.8.1',
         'gwcs': '0.10',
         }
 

--- a/00-Install_and_Setup/environment.yml
+++ b/00-Install_and_Setup/environment.yml
@@ -28,5 +28,4 @@ dependencies:
   - html5lib
   - astroquery>=0.3
   - wcsaxes
-  - imexam>=0.8.1
   - xlwt

--- a/09-Photutils/image_psf_photometry_withNIRCam.ipynb
+++ b/09-Photutils/image_psf_photometry_withNIRCam.ipynb
@@ -401,7 +401,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The next few cells showing calls to `imexam` are not critical, but if you have `imexam` installed you can use it to view the found stars in ds9 (by default) or ginga."
+    "#### Using DS9 or ginga from python\n",
+    "\n",
+    "The next few cells showing calls to `imexam` are not critical, but if you have `imexam` installed you can use it to view the found stars in ds9 (by default) or ginga.  These cells show how to connect to the external image viewer and then send labelling data (in this case the `found_stars`) to it.\n",
+    "\n",
+    "For ds9 to work as an external viewer here, you must have both ds9 installed (available at http://ds9.si.edu/site/Download.html) as well as the XPA executables (available at http://ds9.si.edu/site/XPA.html), necessary for ds9 to communicate with other apps."
    ]
   },
   {
@@ -428,6 +432,7 @@
     "imex.load_fits(im1fn)\n",
     "imex.scale()  # Scale the image to fit the viewer\n",
     "tomark = [(row['x_0'],row['y_0'],i) for i, row in enumerate(found_stars)]\n",
+    "# Comment out the following line if you are using ginga as a viewer, this feature is NOT implemented for ginga\n",
     "imex.mark_region_from_array(tomark)"
    ]
   },
@@ -445,6 +450,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Building a PSF model\n",
+    "\n",
     "Now we build the actual PSF model using the file that the PSF is given in. It is using external knowledge that the PSF is 5x oversampled. The simple oversampling below only works as-is because both are square, but that's true here."
    ]
   },

--- a/09-Photutils/image_psf_photometry_withNIRCam.ipynb
+++ b/09-Photutils/image_psf_photometry_withNIRCam.ipynb
@@ -551,9 +551,11 @@
    "source": [
     "#### Using DS9 or ginga from python (OPTIONAL)\n",
     "\n",
-    "The next few cells showing calls to `imexam` are not critical, but if you have `imexam` installed you can use it to view the found stars in ds9 (by default) or ginga.  These cells show how to connect to the external image viewer and then send labelling data (in this case the `found_stars`) to it.\n",
+    "The next few cells showing calls to `imexam` are not critical, but if you have `imexam` installed you can use it to view the found stars in ds9 (by default) or ginga.  These cells provide a simple example of how to use `imexam` connect to the external interactive image viewer.\n",
     "\n",
-    "For ds9 to work as an external viewer here, you must have both ds9 installed (available at http://ds9.si.edu/site/Download.html) as well as the XPA executables (available at http://ds9.si.edu/site/XPA.html), necessary for ds9 to communicate with other apps.  **MacOS Users**: Calling DS9 from `imexam` has only been tested with the X11 version of ds9, which means you must also have X11 installed on your Mac (the XQuartz project which provides a version of X11 for Mac is available at https://www.xquartz.org/)."
+    "The example here uses `ginga`.  For ds9 to work as an external viewer here, you must uncomment the code noted below and have both ds9  (available at http://ds9.si.edu/site/Download.html) and the XPA executables (available at http://ds9.si.edu/site/XPA.html) installed.  **MacOS/Linux Users**: An easy way to get ds9 installed is to use the command:\n",
+    "\n",
+    "`conda install ds9 --override-channels -c http://ssb.stsci.edu/astroconda`"
    ]
   },
   {
@@ -566,9 +568,9 @@
     "# imex.load_fits command.  This allows the connection to the viewer to be established BEFORE we attempt to \n",
     "# load the fits image.\n",
     "import imexam\n",
-    "imex = imexam.connect()\n",
-    "# Comment out the line above and uncomment the following line to use ginga\n",
-    "# imex=imexam.connect(viewer='ginga')"
+    "imex = imexam.connect(viewer='ginga')\n",
+    "# Comment out the line above and uncomment the following line to use ds9\n",
+    "# imex=imexam.connect()"
    ]
   },
   {
@@ -579,9 +581,9 @@
    "source": [
     "imex.load_fits(im1fn)\n",
     "imex.scale()  # Scale the image to fit the viewer\n",
-    "tomark = [(row['x_0'],row['y_0'],i) for i, row in enumerate(found_stars)]\n",
-    "# Comment out the following line if you are using ginga as a viewer, this feature is NOT implemented for ginga\n",
-    "imex.mark_region_from_array(tomark)"
+    "# Uncomment the following lines if you are using ds9 as a viewer, this feature is NOT implemented for ginga\n",
+    "# tomark = [(row['x_0'],row['y_0'],i) for i, row in enumerate(found_stars)]\n",
+    "# imex.mark_region_from_array(tomark)"
    ]
   },
   {

--- a/09-Photutils/image_psf_photometry_withNIRCam.ipynb
+++ b/09-Photutils/image_psf_photometry_withNIRCam.ipynb
@@ -401,57 +401,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Using DS9 or ginga from python\n",
-    "\n",
-    "The next few cells showing calls to `imexam` are not critical, but if you have `imexam` installed you can use it to view the found stars in ds9 (by default) or ginga.  These cells show how to connect to the external image viewer and then send labelling data (in this case the `found_stars`) to it.\n",
-    "\n",
-    "For ds9 to work as an external viewer here, you must have both ds9 installed (available at http://ds9.si.edu/site/Download.html) as well as the XPA executables (available at http://ds9.si.edu/site/XPA.html), necessary for ds9 to communicate with other apps."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# As a timing issue, it is best to handle the import and connection in a separate cell from the \n",
-    "# imex.load_fits command.  This allows the connection to the viewer to be established BEFORE we attempt to \n",
-    "# load the fits image.\n",
-    "import imexam\n",
-    "imex = imexam.connect()\n",
-    "# Comment out the line above and uncomment the following line to use ginga\n",
-    "# imex=imexam.connect(viewer='ginga')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "imex.load_fits(im1fn)\n",
-    "imex.scale()  # Scale the image to fit the viewer\n",
-    "tomark = [(row['x_0'],row['y_0'],i) for i, row in enumerate(found_stars)]\n",
-    "# Comment out the following line if you are using ginga as a viewer, this feature is NOT implemented for ginga\n",
-    "imex.mark_region_from_array(tomark)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Shut down the connection\n",
-    "imex.close()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Building a PSF model\n",
-    "\n",
     "Now we build the actual PSF model using the file that the PSF is given in. It is using external knowledge that the PSF is 5x oversampled. The simple oversampling below only works as-is because both are square, but that's true here."
    ]
   },
@@ -600,6 +549,55 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Using DS9 or ginga from python (OPTIONAL)\n",
+    "\n",
+    "The next few cells showing calls to `imexam` are not critical, but if you have `imexam` installed you can use it to view the found stars in ds9 (by default) or ginga.  These cells show how to connect to the external image viewer and then send labelling data (in this case the `found_stars`) to it.\n",
+    "\n",
+    "For ds9 to work as an external viewer here, you must have both ds9 installed (available at http://ds9.si.edu/site/Download.html) as well as the XPA executables (available at http://ds9.si.edu/site/XPA.html), necessary for ds9 to communicate with other apps.  **MacOS Users**: Calling DS9 from `imexam` has only been tested with the X11 version of ds9, which means you must also have X11 installed on your Mac (the XQuartz project which provides a version of X11 for Mac is available at https://www.xquartz.org/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# As a timing issue, it is best to handle the import and connection in a separate cell from the \n",
+    "# imex.load_fits command.  This allows the connection to the viewer to be established BEFORE we attempt to \n",
+    "# load the fits image.\n",
+    "import imexam\n",
+    "imex = imexam.connect()\n",
+    "# Comment out the line above and uncomment the following line to use ginga\n",
+    "# imex=imexam.connect(viewer='ginga')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imex.load_fits(im1fn)\n",
+    "imex.scale()  # Scale the image to fit the viewer\n",
+    "tomark = [(row['x_0'],row['y_0'],i) for i, row in enumerate(found_stars)]\n",
+    "# Comment out the following line if you are using ginga as a viewer, this feature is NOT implemented for ginga\n",
+    "imex.mark_region_from_array(tomark)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Shut down the connection\n",
+    "imex.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Exercises"
    ]
   },
@@ -648,7 +646,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/09-Photutils/image_psf_photometry_withNIRCam.ipynb
+++ b/09-Photutils/image_psf_photometry_withNIRCam.ipynb
@@ -401,7 +401,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The next cell is not critical, but if you have `imexam` installed you can use it to view the found stars in ds9."
+    "The next few cells showing calls to `imexam` are not critical, but if you have `imexam` installed you can use it to view the found stars in ds9 (by default) or ginga."
    ]
   },
   {
@@ -410,12 +410,35 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# As a timing issue, it is best to handle the import and connection in a separate cell from the \n",
+    "# imex.load_fits command.  This allows the connection to the viewer to be established BEFORE we attempt to \n",
+    "# load the fits image.\n",
     "import imexam\n",
-    "\n",
     "imex = imexam.connect()\n",
+    "# Comment out the line above and uncomment the following line to use ginga\n",
+    "# imex=imexam.connect(viewer='ginga')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "imex.load_fits(im1fn)\n",
+    "imex.scale()  # Scale the image to fit the viewer\n",
     "tomark = [(row['x_0'],row['y_0'],i) for i, row in enumerate(found_stars)]\n",
     "imex.mark_region_from_array(tomark)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Shut down the connection\n",
+    "imex.close()"
    ]
   },
   {
@@ -618,7 +641,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/09-Photutils/image_psf_photometry_withNIRCam.ipynb
+++ b/09-Photutils/image_psf_photometry_withNIRCam.ipynb
@@ -549,57 +549,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Using DS9 or ginga from python (OPTIONAL)\n",
-    "\n",
-    "The next few cells showing calls to `imexam` are not critical, but if you have `imexam` installed you can use it to view the found stars in ds9 (by default) or ginga.  These cells provide a simple example of how to use `imexam` connect to the external interactive image viewer.\n",
-    "\n",
-    "The example here uses `ginga`.  For ds9 to work as an external viewer here, you must uncomment the code noted below and have both ds9  (available at http://ds9.si.edu/site/Download.html) and the XPA executables (available at http://ds9.si.edu/site/XPA.html) installed.  **MacOS/Linux Users**: An easy way to get ds9 installed is to use the command:\n",
-    "\n",
-    "`conda install ds9 --override-channels -c http://ssb.stsci.edu/astroconda`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# As a timing issue, it is best to handle the import and connection in a separate cell from the \n",
-    "# imex.load_fits command.  This allows the connection to the viewer to be established BEFORE we attempt to \n",
-    "# load the fits image.\n",
-    "import imexam\n",
-    "imex = imexam.connect(viewer='ginga')\n",
-    "# Comment out the line above and uncomment the following line to use ds9\n",
-    "# imex=imexam.connect()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "imex.load_fits(im1fn)\n",
-    "imex.scale()  # Scale the image to fit the viewer\n",
-    "# Uncomment the following lines if you are using ds9 as a viewer, this feature is NOT implemented for ginga\n",
-    "# tomark = [(row['x_0'],row['y_0'],i) for i, row in enumerate(found_stars)]\n",
-    "# imex.mark_region_from_array(tomark)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Shut down the connection\n",
-    "imex.close()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Exercises"
    ]
   },
@@ -648,7 +597,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I added some clarifying comments in the **09-Photutils/image_psf_photometry_withNIRCam** notebook about how `imexam` can be used.  I moved the entire section of imexam to the end of the notebook (just before the exercises) and labeled it as optional, which it really is.   I also added some notes on the requirements for ds9 and how XPA must also be installed.