### PR TITLE
Update environment

### DIFF
--- a/00-Install_and_Setup/environment.yml
+++ b/00-Install_and_Setup/environment.yml
@@ -2,7 +2,6 @@ name: astropy-workshop
 
 channels:
   - astropy
-  - conda-forge
 
 dependencies:
   - python=3.6
@@ -26,6 +25,6 @@ dependencies:
   - requests
   - keyring
   - html5lib
-  - astroquery>=0.3
-  - wcsaxes
   - xlwt
+  - pip:
+    - astroquery

--- a/00-Install_and_Setup/environment.yml
+++ b/00-Install_and_Setup/environment.yml
@@ -28,3 +28,4 @@ dependencies:
   - xlwt
   - pip:
     - astroquery
+    - --pre


### PR DESCRIPTION
- pip install astroquery
- don't install deprecated wcsaxes
- don't rely on conda-forge, everything is available via defaults and astropy channels

this should fix #35 

Also I wonder what's the reason to use Python 3.6 and not Python 3.7?

Also, conda is seriously slow these days. Maybe pip should be considered instead? (I mean using conda to set up the environment, but use pip to install the packages into it. It can be done seamlessly using the same environment file). 