### PR TITLE
Removed conda-forge as a channel from environment.yml.  

### DIFF
--- a/00-Install_and_Setup/environment.yml
+++ b/00-Install_and_Setup/environment.yml
@@ -2,7 +2,6 @@ name: astropy-workshop
 
 channels:
   - astropy
-  - conda-forge
 
 dependencies:
   - python=3.6
@@ -29,3 +28,4 @@ dependencies:
   - astroquery>=0.3
   - wcsaxes
   - xlwt
+


### PR DESCRIPTION
Based on the recommendation of @bsipocz in a brief Slack conversation, I tested and discovered the entire installation could be done using only the default and astropy channels on macOS, windows (64bit), and linux (64bit).  There is no need to have the conda-forge channel in the `environment.yml` file and so I removed it.