### PR TITLE
Quick tweak to installation README (proper pip upgrade instructions)

### DIFF
--- a/00-Install_and_Setup/README.md
+++ b/00-Install_and_Setup/README.md
@@ -68,7 +68,7 @@ If the script reports that some of the versions don't match, update the reported
     
 The exception to this is if the `astroquery` package is reported as out-of-date.  If you created the `astropy-workshop` environment using the `environment.yml` file, `astroquery` is installed using the `pip` package manager, because it typically has access to newer versions of `astroquery`.  To update a package installed with `pip`, use:
 
-	pip install <packagename> --upgrade
+	pip install --pre <packagename> --upgrade
     
 ## Additional Resources
 - [Set up git](https://help.github.com/articles/set-up-git/)


### PR DESCRIPTION
Fixed the pip upgrading information in the README to include --pre, recommended by @bsipocz due to astroquery's "still messed up version numbering"