### PR TITLE
Update environment requirements for new photutils

### DIFF
--- a/00-Install_and_Setup/check_env.py
+++ b/00-Install_and_Setup/check_env.py
@@ -42,11 +42,12 @@ pkgs = {'IPython': '7.2',
         'scipy': '1.1',
         'matplotlib': '2.2.3',
         'astropy': '3.1',
-        'photutils': '0.5',
+        'photutils': '0.6',
         'skimage': '0.14',
         'pandas': '0.23',
         'astroquery': '0.3',
         'gwcs': '0.10',
+        'webbpsf': '0.8'
         }
 
 errors = []

--- a/00-Install_and_Setup/environment.yml
+++ b/00-Install_and_Setup/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - cython
   - matplotlib>=2.2.3
   - astropy>=3.1
-  - photutils>=0.5
+  - photutils>=0.6
   - scikit-image>=0.14
   - pandas>=0.23
   - glue-vispy-viewers>=0.6
@@ -26,6 +26,7 @@ dependencies:
   - keyring
   - html5lib
   - xlwt
+  - webbpsf>=0.8
   - pip:
     - astroquery
     - --pre


### PR DESCRIPTION
A little late unfortunately, but this PR specifies the latest version of `photutils` and requires installation of `webbpsf` in the workshop environment - both needed to demo new `photutils` features.