### PR TITLE
Fixed typo in link to updating instructions from README

### DIFF
--- a/00-Install_and_Setup/README.md
+++ b/00-Install_and_Setup/README.md
@@ -74,4 +74,4 @@ The exception to this is if the `astroquery` package is reported as out-of-date.
 - [Set up git](https://help.github.com/articles/set-up-git/)
 - [Conda Users Guide](https://conda.io/docs/user-guide/index.html)
 - [Astropy Install Instructions](http://docs.astropy.org/en/stable/install.html)
-- [Instructions for keeping this repo up to date](Updating.md)
+- [Instructions for keeping this repo up to date](UPDATING.md)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you would like to get a head start with the tools we will be concentrating on
 * [Modeling and Fitting](http://docs.astropy.org/en/stable/modeling/index.html)
 * [Astropy WCS](http://docs.astropy.org/en/stable/wcs/index.html)
 * [photutils](http://photutils.readthedocs.io/)
-* [Github](https://guides.github.com/activities/hello-world/)
+* [specutils](https://specutils.readthedocs.io/)
 * [Contributing to Astropy](http://docs.astropy.org/en/stable/development/workflow/development_workflow.html)
 * [Affiliated Packages](http://www.astropy.org/affiliated/)
 
@@ -72,6 +72,7 @@ If you would like to get a head start with the tools we will be concentrating on
   * [Glue](http://glueviz.org/)
   * [SpecViz](http://specviz.readthedocs.io/en/latest/)
   * [Generalized WCS](http://gwcs.readthedocs.io/en/stable/)
+  * [Git and Github](https://guides.github.com/activities/hello-world/)
 
 ## Problems or Questions?
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ If you would like to get a head start with the tools we will be concentrating on
   * [Generalized WCS](http://gwcs.readthedocs.io/en/stable/)
   * [Git and Github](https://guides.github.com/activities/hello-world/)
   * [Git branching](https://learngitbranching.js.org/) 
+  * [Git branching](https://learngitbranching.js.org/) 
 
 ## Problems or Questions?
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ If you would like to get a head start with the tools we will be concentrating on
   * [Generalized WCS](http://gwcs.readthedocs.io/en/stable/)
   * [Git and Github](https://guides.github.com/activities/hello-world/)
   * [Git branching](https://learngitbranching.js.org/) 
-  * [Git branching](https://learngitbranching.js.org/) 
 
 ## Problems or Questions?
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ If you would like to get a head start with the tools we will be concentrating on
   * [SpecViz](http://specviz.readthedocs.io/en/latest/)
   * [Generalized WCS](http://gwcs.readthedocs.io/en/stable/)
   * [Git and Github](https://guides.github.com/activities/hello-world/)
+  * [Git branching](https://learngitbranching.js.org/) 
 
 ## Problems or Questions?
 


### PR DESCRIPTION
Fixed typo in link to updating instructions from README.md. Link doesn't work on file system that is 'case sensitive' (including github). Can you push this through @eteq ?