### PR TITLE
adjust schedule to move up community-description sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,12 @@ DO NOT WAIT UNTIL THE DAY OF THE WORKSHOP.
 |11:00 - 11:30 | [I/O: FITS and ASCII](05-FITS) |  |
 |11:30 - 12:00 | [Astropy Tables](06-Tables)| |
 |**12:00 - 1:00**| **LUNCH** | *On your own* |
-|1:00 - 1:30 | [WCS and Images](08-WCS) | |
-|1:30 - 2:30 | [Photutils](09-Photutils) |  |
-**2:30 - 3:00** | **BREAK** | *Snacks Provided* |
-|3:00 - 4:00 | [Specutils](09b-Specutils) | |
-|*3:30* | *Last call on snacks* | |
-|4:00 - 4:15 | [Astropy Communities](10-WrapUp) |  |
-|4:15 - 4:45 | [Contributing to Astropy](10-WrapUp) |  |
+|1:00 - 1:15 | [Astropy Communities](10-WrapUp) |  |
+|1:15 - 1:45 | [Contributing to Astropy](10-WrapUp) |  |
+|1:45 - 2:15 | [WCS and Images](08-WCS) | |
+**2:15 - 2:45** | **BREAK** | *Snacks Provided* |
+|2:45 - 3:45 | [Photutils](09-Photutils) |  |
+|3:45 - 4:45 | [Specutils](09b-Specutils) | |
 |4:45 - 5:00 | [Survey](10-WrapUp) |  |
 
 ## Description


### PR DESCRIPTION
This addresses the question raised in #56 of how to put the "community" discussions before the end of the day when people might start leaving.

This change puts it right after lunch, as a second round of more "lecture" style stuff like at the start (vs the other parts which are more tutorial-y).  The down-side is that it results in photutils and specutils being at the very end, which is perhaps appropriate as they combine material from all the early sessions, but are also a bit more technically complex (before they were split up by the break to make it a bit easier to manage the transition).

(This would complete the first step of #65)