### PR TITLE
Update install instructions

### DIFF
--- a/00-Install_and_Setup/README.md
+++ b/00-Install_and_Setup/README.md
@@ -1,7 +1,8 @@
 # Getting Started with Python and Anaconda
 
 Please come to the workshop with a laptop already configured as described below.
-If you have any problems with any of these steps, please
+If you have any problems with any of these steps, please check if your problem has
+already been reported at [the issue tracker](https://github.com/astropy/astropy-workshop/issues/). If not,
 [ask your question in the issue tracker](https://github.com/astropy/astropy-workshop/issues/new?assignees=&labels=workshop-question&template=question-from-workshop-participant.md&title=%5BQuestion%5D+Summarize+your+question+here).
 
 ## 1. Clone This Repository

--- a/00-Install_and_Setup/README.md
+++ b/00-Install_and_Setup/README.md
@@ -2,7 +2,7 @@
 
 Please come to the workshop with a laptop already configured as described below.
 If you have any problems with any of these steps, please
-[open an issue](https://github.com/astropy/astropy-workshop/issues).
+[ask your question in the issue tracker](https://github.com/astropy/astropy-workshop/issues/new?assignees=&labels=workshop-question&template=question-from-workshop-participant.md&title=%5BQuestion%5D+Summarize+your+question+here).
 
 ## 1. Clone This Repository
 
@@ -22,7 +22,8 @@ update your copy of the repository if updates are made.
 *Miniconda is a free minimal installer for conda. It is a small, bootstrap
 version of Anaconda that includes only conda, Python, the packages they depend
 on, and a small number of other useful packages, including pip, zlib and a few
-others.*
+others. Note, though, that if you have either miniconda or the full Anaconda 
+already installed, you can skip to the next step.*
 
 Check if Miniconda is already installed.
 
@@ -36,7 +37,9 @@ On Windows, you might also need
 
 ## 3. Create a conda environment for the workshop
 
-*Miniconda includes an environment manager called conda. You can create,
+*Miniconda includes an environment manager called conda. Environments
+allow you to have multiple sets of Python packages installed at the same 
+time, making reproducibility and upgrades easier. You can create,
 export, list, remove, and update environments that have different versions of
 Python and/or packages installed in them.*
 

--- a/00-Install_and_Setup/README.md
+++ b/00-Install_and_Setup/README.md
@@ -1,77 +1,125 @@
 # Getting Started with Python and Anaconda
 
 Please come to the workshop with a laptop already configured as described below.
-If you have any problems with any of these steps, please [open an issue](https://github.com/astropy/astropy-workshop/issues).
+If you have any problems with any of these steps, please
+[open an issue](https://github.com/astropy/astropy-workshop/issues).
 
 ## 1. Clone This Repository
 
-Download the workshop folder using [git](https://help.github.com/articles/set-up-git/):
+Download the workshop folder using
+[git](https://help.github.com/articles/set-up-git/):
 
     % git clone https://github.com/astropy/astropy-workshop.git
 
-If you don't have git installed, you can download the ZIP file by pressing the green *Clone or download* button at https://github.com/astropy/astropy-workshop and selecting *Download ZIP*.  However, this option is less prefered because it makes it more difficult for you to update your copy of the repository if updates are made.
+If you don't have git installed, you can download the ZIP file by pressing the
+green *Clone or download* button at
+https://github.com/astropy/astropy-workshop and selecting *Download ZIP*.
+However, this option is not recommended because it impedes the ability to
+update your copy of the repository if updates are made.
 
-## 2. Install Anaconda (if needed)
+## 2. Install Miniconda (if needed)
 
-*Anaconda includes conda, conda build, Python and 100+ automatically installed, open source scientific packages and their dependencies that have been tested to work well together, including SciPy, NumPy and many others.*
+*Miniconda is a free minimal installer for conda. It is a small, bootstrap
+version of Anaconda that includes only conda, Python, the packages they depend
+on, and a small number of other useful packages, including pip, zlib and a few
+others.*
 
-Check if Anaconda is already installed.
-    
+Check if Miniconda is already installed.
+
     % conda info
 
-If Anaconda is not already installed, follow the Anaconda instructions for your operating system: 
-https://docs.anaconda.com/anaconda/install/
-   
-Choose between installing the full Anaconda (3 GB) or  Miniconda (400 MB).
-Miniconda comes with fewer default packages so it's faster to download and takes up less drive space. 
+If Miniconda is not already installed, follow these instructions for your
+operating system: https://docs.conda.io/en/latest/miniconda.html
+
+On Windows, you might also need
+[additional compilers](https://github.com/conda/conda-build/wiki/Windows-Compilers).
 
 ## 3. Create a conda environment for the workshop
-*Anaconda includes an environment manager called conda.  You can create, export, list, remove and update environments that have different versions of Python and/or packages installed in them.* 
 
-[Create a conda environment for this workshop using a yml file](https://conda.io/docs/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file). 
-The python version and all needed packages, including astropy, are listed in the [environment.yml](https://github.com/astropy/astropy-workshop/blob/master/00-Install_and_Setup/environment.yml) file
+*Miniconda includes an environment manager called conda. You can create,
+export, list, remove, and update environments that have different versions of
+Python and/or packages installed in them.*
 
-On mac or linux, open your terminal and verify your shell environment: 
+[Create a conda environment for this workshop using a yml file](https://conda.io/docs/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file).
+The python version and all needed packages, including astropy, are listed in the
+[environment.yml](https://github.com/astropy/astropy-workshop/blob/master/00-Install_and_Setup/environment.yml) file.
 
-    % echo $SHELL 
-    
-If the output text does not contain `bash` then switch to the bash shell before being able to run anything related to Anaconda.
+On Mac or Linux, open your terminal and verify your shell environment:
 
-On windows, just open the `Anaconda Prompt` terminal app.
+    % echo $SHELL
 
-Now navigate to this directory in the terminal.  For example, if you installed the astropy-workshop directory in your home directory, you could type:
+If the output text does not contain `bash`, switch to the bash shell before
+being able to run anything related to conda.
 
-On a mac/linux:
+On Windows, open the `Anaconda Prompt` terminal app.
 
-    % cd astropy-workshop/00-Install_and_Setup/  
+Now navigate to this directory in the terminal. For example, if you installed
+the astropy-workshop directory in your home directory, you could type the
+following.
 
-In windows:
+On a Mac/Linux:
+
+    % cd astropy-workshop/00-Install_and_Setup/
+
+On Windows:
 
     % cd astropy-workshop\00-Install_and_Setup\
 
-And finally, on any platform, to install and activate the astropy-workshop environment, type:
+And finally, on any platform, to install and activate the astropy-workshop
+environment, type:
 
     % conda env create -n astropy-workshop --file environment.yml
     % conda activate astropy-workshop
 
 ## 4. Check Installation
 
-The name of the new conda environment created above should be displayed next to the terminal prompt: `(astropy-workshop) % `
+The name of the new conda environment created above should be displayed next
+to the terminal prompt: `(astropy-workshop) %`
 
-Run the check_env.py script to check the Python environment and some of the required dependencies:
+Run the `check_env.py` script to check the Python environment and some of the
+required dependencies:
 
     (astropy-workshop) % python check_env.py
 
-If the script reports that some of the versions don't match, update the reported packages using the ``conda update``, namely:
+If the script reports that some of the versions do not match, check first
+whether the package was installed using conda or pip, then update accordingly.
+The example below a fake package called `packagename`; replace it with the
+actual package that you need to update.
 
-    (astropy-workshop) % conda update <packagename>
-    
-The exception to this is if the `astroquery` package is reported as out-of-date.  If you created the `astropy-workshop` environment using the `environment.yml` file, `astroquery` is installed using the `pip` package manager, because it typically has access to newer versions of `astroquery`.  To update a package installed with `pip`, use:
+    (astropy-workshop) % conda list packagename
 
-    (astropy-workshop) % pip install --pre <packagename> --upgrade
-    
+If it was installed with conda, you will see (the channel column might or
+might not be populated):
+
+    # packages in environment at .../miniconda/envs/astropy-workshop:
+    #
+    # Name                    Version                   Build  Channel
+    packagename               X.Y.Z         py37hf484d3e_1000
+
+Otherwise, if it was installed with pip, you will see the channel stating the
+name `pypi`:
+
+    # packages in environment at .../miniconda/envs/astropy-workshop:
+    #
+    # Name                    Version                   Build  Channel
+    packagename               X.Y.Z                     pypi_0    pypi
+
+To update the reported package with conda:
+
+    (astropy-workshop) % conda update packagename
+
+Otherwise, to update with pip:
+
+    (astropy-workshop) % pip install packagename --upgrade
+
+The exception to this is if the `astroquery` package is reported as
+out-of-date, always update to its pre-release version with pip:
+
+    (astropy-workshop) % pip install astroquery --pre --upgrade
+
 ## Additional Resources
+
 - [Set up git](https://help.github.com/articles/set-up-git/)
-- [Conda Users Guide](https://conda.io/docs/user-guide/index.html)
-- [Astropy Install Instructions](http://docs.astropy.org/en/stable/install.html)
+- [Conda Users Guide](https://docs.conda.io/projects/conda/en/latest/user-guide/)
+- [Astropy Install Instructions](http://docs.astropy.org/en/latest/install.html)
 - [Instructions for keeping this repo up to date](UPDATING.md)

--- a/00-Install_and_Setup/README.md
+++ b/00-Install_and_Setup/README.md
@@ -23,7 +23,7 @@ update your copy of the repository if updates are made.
 *Miniconda is a free minimal installer for conda. It is a small, bootstrap
 version of Anaconda that includes only conda, Python, the packages they depend
 on, and a small number of other useful packages, including pip, zlib and a few
-others. Note, though, that if you have either miniconda or the full Anaconda 
+others. Note, though, that if you have either Miniconda or the full Anaconda 
 already installed, you can skip to the next step.*
 
 Check if Miniconda is already installed.

--- a/00-Install_and_Setup/UPDATING.md
+++ b/00-Install_and_Setup/UPDATING.md
@@ -1,82 +1,102 @@
 # Getting Everything Up To Date
 
-If you downloaded and installed your Astropy Workshop directory and conda environment before the workshop, good for you!  We appreciate it.  However, there may well have been some updates made to the materials we are going to use in the workshop, so...
+If you downloaded and installed your Astropy Workshop directory and conda
+environment before the workshop, good for you!  We appreciate it.
+However, there may well have been some updates made to the materials we are
+going to use in the workshop, so...
 
 ## 1. Updating your Astropy Workshop files
 
 ### Updating a git cloned repository
 
-Assuming you cloned the astropy-workshop git repository all you have to do is open up a command line, change your location to that directory and then perform a `git pull` using something like:
+Assuming you cloned the astropy-workshop git repository, open up a terminal,
+change your location to that directory, and then follow the instructions below:
 
     % cd astropy-workshop
     % git status
 
-If this does NOT report any modified files in your local copy of `astropy-workshop`, all you have to do to update the workshop files is
+If this does NOT report any modified files in your local copy of
+`astropy-workshop`, do this to update the workshop files:
 
     % git pull
 
-If there are modified local files reported, your best option (which *will destroy* any local file changes you made):
+If there are modified local files reported, your best option instead is as
+follows (which *will destroy* any local file changes you made):
 
     % git fetch --all
     % git reset --hard origin/master
 
-**ADVANCED OPTION**: This is not a `git` workshop, but if you want to keep your file modifications, you can commit your modified files to the git repository  and then create a new branch from the current version on the github server:
+**ADVANCED OPTION**: This is not a git workshop, but if you want to keep
+your file modifications, you can commit your modified files to the git
+repository and then create a new branch from the current version on the
+GitHub server:
 
-    % git commit -a `Save my modified files`
+    % git commit -a "Save my modified files"
     % git fetch origin
-    % git checkout -b workshop-master origin/master
+    % git checkout origin/master -b workshop-master
 
-Probably overkill unless you already use `git` regularly.
-
+This is probably overkill unless you already use git regularly. When in doubt,
+please ask the instructors or helpers.
 
 ### Updating a ZIP downloaded directory
 
-If you don't have `git` installed and used the (disfavored) *Download ZIP* option, you will have to do that again and overwrite the original directory you had.
+If you do not have git installed and used the *Download ZIP* option
+(not recommended), you will have to do that again and overwrite the original
+directory you had.
 
 ## 2. Double-checking your Conda environment
 
-Assuming you properly installed your astropy-workshop conda environment, you should be able to (a) activate that conda environment, (b) go the the original installation directory and then (c) check to see if your environment still meets the requirements.  Let's do that now.
+Assuming you properly installed your astropy-workshop conda environment, you
+should be able to:
 
-Start by activating the conda environment:
-    
+a. activate that conda environment, and
+b. go the the original installation directory, and then
+c. check to see if your environment still meets the requirements.
+
+Let's do that now. Start by activating the conda environment:
+
     % conda activate astropy-workshop
 
-Then  switch to the directory containing the installer by doing the following:
+You will notice a change in your prompt; e.g., `(astropy-workshop) %`.
+Then, switch to the directory containing the installer by doing the following.
 
-On a mac/linux (your directory path may be different):
+On a Mac/Linux (your directory path may be different):
 
-    % cd astropy-workshop/00-Install_and_Setup/  
+    (astropy-workshop) % cd astropy-workshop/00-Install_and_Setup/
 
-In windows (your directory path may be different):
+On Windows (your directory path may be different):
 
-    % cd astropy-workshop\00-Install_and_Setup\
-    
-Then we check if the environment is still up to date:
+    (astropy-workshop) % cd astropy-workshop\00-Install_and_Setup\
 
-    % python check_env.py
-    
-If this check reports a problem with a package, see what to do below below.
+Next, we check if the environment is still up to date:
+
+    (astropy-workshop) % python check_env.py
+
+If this check reports a problem with a package, see what to do below.
 
 ## 3. Updating python packages
 
-If the `check_env.py` script reports that some package `<packagename>` is not of a recent enough build, we need to check where the package came from:
+If the `check_env.py` script reports that some package called `packagename`
+is not of a recent enough build, we need to check where the package came from
+(replace `packagename` with the real package name):
 
-    % conda list <packagename>
+    (astropy-workshop) % conda list packagename
 
-If the "Build" of the package does *NOT* say `<pip>`,  you can then update the package using
+If the "Build" of the package does *NOT* say `pypi`,  you can then update the
+package using:
 
-    % conda update <packagename>
+    (astropy-workshop) % conda update packagename
 
-If the package was installed with `pip`, you can update it to the lastest pre-release package using the command:
+If the package was installed from PyPI with pip, you can update it to the
+latest PyPI release using:
 
-    % pip install --upgrade <packagename>
-    
-Note that if the version reported includes `dev` in the version, it may be a pre-release version of the package and you may need to use:
-  
-    % pip install --pre --upgrade <packagename> 
+    (astropy-workshop) % pip install packagename --upgrade
 
-to update to the latest pre-release.
-      
+If you know you need the pre-release version from PyPI (e.g., `astroquery`),
+use:
+
+    (astropy-workshop) % pip install packagename --pre --upgrade
+
 Once you have performed the updates, check your installation again using:
 
-    % python check_env.py
+    (astropy-workshop) % python check_env.py

--- a/00-Install_and_Setup/check_env.py
+++ b/00-Install_and_Setup/check_env.py
@@ -6,10 +6,33 @@ Usage::
   % python check_env.py
 
 """
-from __future__ import print_function
-
-import sys
 from distutils.version import LooseVersion
+
+# NOTE: Update minversion values as needed.
+# This should match environment.yml file.
+PKGS = {'IPython': '7.2',
+        'cython': None,
+        'jupyter': None,
+        'notebook': '5.7',
+        'numpy': '1.16',
+        'scipy': '1.1',
+        'skimage': '0.14',
+        'matplotlib': '2.2.3',
+        'pandas': '0.23',
+        'bs4': None,  # beautifulsoup4
+        'keyring': None,
+        'html5lib': None,
+        'xlwt': None,
+        'requests': None,
+        'jupyterlab': None,
+        'astropy': '4.0',
+        'asdf': None,
+        'gwcs': '0.10',
+        'photutils': '0.5',
+        'specutils': '0.5.1',
+        'glue_vispy_viewers': '0.6',
+        'glue': '0.9.1',  # glueviz
+        'astroquery': '0.3'}
 
 
 def check_package(package_name, minimum_version=None, verbose=True):
@@ -17,44 +40,36 @@ def check_package(package_name, minimum_version=None, verbose=True):
     try:
         pkg = __import__(package_name)
     except ImportError as err:
-        print('Error: Failed import: {0}'.format(err))
+        print(f'Error: Failed import: {err}')
         errors = True
     else:
-        if package_name == 'xlwt':
+        if package_name in ('jupyter', 'keyring'):
+            installed_version = ''
+        elif package_name == 'xlwt':
             installed_version = pkg.__VERSION__
         else:
             installed_version = pkg.__version__
         if (minimum_version is not None and
-            LooseVersion(installed_version) <
+                LooseVersion(installed_version) <
                 LooseVersion(str(minimum_version))):
-            print('Error: {0} version {1} or later is required, you '
-                  'have version {2}'.format(package_name, minimum_version,
-                                            installed_version))
+            print(f'Error: {package_name} version {minimum_version} or '
+                  f'later is required, you have version {installed_version}')
             errors = True
         if not errors and verbose:
             print('Found', package_name, installed_version)
     return errors
 
 
-pkgs = {'IPython': '7.2',
-        'notebook': '5.7',
-        'numpy': '1.14',
-        'scipy': '1.1',
-        'matplotlib': '2.2.3',
-        'astropy': '3.1',
-        'photutils': '0.5',
-        'specutils': '0.5.1',
-        'skimage': '0.14',
-        'pandas': '0.23',
-        'astroquery': '0.3',
-        'gwcs': '0.10',
-        }
+def run_checks():
+    errors = []
+    for package_name, min_version in PKGS.items():
+        errors.append(check_package(package_name, minimum_version=min_version))
+    if any(errors):
+        print('\nThere are errors that you must resolve before running the '
+              'tutorials.')
+    else:
+        print('\nYour Python environment is good to go!')
 
-errors = []
-for package_name, min_version in pkgs.items():
-    errors.append(check_package(package_name, minimum_version=min_version))
-if any(errors):
-    print('\nThere are errors that you must resolve before running the '
-          'tutorials.')
-else:
-    print('\nYour Python environment is good to go!')
+
+if __name__ == '__main__':
+    run_checks()

--- a/00-Install_and_Setup/environment.yml
+++ b/00-Install_and_Setup/environment.yml
@@ -4,6 +4,7 @@ channels:
   - astropy
 
 dependencies:
+  - pip
   - python=3.7
   - ipython>=7.2
   - cython

--- a/00-Install_and_Setup/environment.yml
+++ b/00-Install_and_Setup/environment.yml
@@ -4,28 +4,29 @@ channels:
   - astropy
 
 dependencies:
-  - python=3.6
-  - numpy>=1.14
-  - scipy>=1.1
+  - python=3.7
+  - ipython>=7.2
   - cython
-  - matplotlib>=2.2.3
-  - astropy>=3.1
-  - photutils>=0.5
-  - scikit-image>=0.14
-  - pandas>=0.23
-  - glue-vispy-viewers>=0.6
-  - glueviz>=0.9.1
-  - specutils>=0.5.1
   - jupyter
   - notebook>=5.7
-  - ipython>=7.2
-  - asdf
-  - gwcs>=0.10
-  - beautifulsoup4
-  - requests
-  - keyring
-  - html5lib
-  - xlwt
+  - numpy>=1.16
+  - scipy>=1.1
+  - scikit-image>=0.14
+  - matplotlib>=2.2.3
+  - pandas>=0.23
   - pip:
+    - beautifulsoup4
+    - keyring
+    - html5lib
+    - xlwt
+    - requests
+    - jupyterlab
+    - "astropy>=4.0rc1"
+    - asdf
+    - "gwcs>=0.10"
+    - "photutils>=0.5"
+    - "specutils>=0.5.1"
+    - "glue-vispy-viewers>=0.6"
+    - "glueviz>=0.9.1"
     - astroquery
     - --pre


### PR DESCRIPTION
Fix #72 . Anaconda full install is overkill, so I also changed the instructions to point to Miniconda.

Here is an example `check_env.py` output from an env created with this patch using `conda` 4.7.12:

```
(astropy-workshop) % python check_env.py 
Found IPython 7.9.0
Found cython 0.29.13
Found jupyter 
Found notebook 6.0.2
Found numpy 1.17.3
Found scipy 1.3.1
Found skimage 0.15.0
Found matplotlib 3.1.1
Found pandas 0.25.3
Found bs4 4.8.1
Found keyring 
Found html5lib 1.0.1
Found xlwt 1.3.0
Found requests 2.22.0
Found jupyterlab 2.0.0a1
Found astropy 4.0rc1
Found asdf 2.4.2
Found gwcs 0.11.0
Found photutils 0.7.1
Found specutils 0.6
Found glue_vispy_viewers 0.12.2
Found glue 0.15.6
Found astroquery 0.4.dev0

Your Python environment is good to go!
```