### PR TITLE
Pin astroquery for AAS235

### DIFF
--- a/00-Install_and_Setup/README.md
+++ b/00-Install_and_Setup/README.md
@@ -23,7 +23,7 @@ update your copy of the repository if updates are made.
 *Miniconda is a free minimal installer for conda. It is a small, bootstrap
 version of Anaconda that includes only conda, Python, the packages they depend
 on, and a small number of other useful packages, including pip, zlib and a few
-others. Note, though, that if you have either Miniconda or the full Anaconda 
+others. Note, though, that if you have either Miniconda or the full Anaconda
 already installed, you can skip to the next step.*
 
 Check if Miniconda is already installed.
@@ -39,7 +39,7 @@ On Windows, you might also need
 ## 3. Create a conda environment for the workshop
 
 *Miniconda includes an environment manager called conda. Environments
-allow you to have multiple sets of Python packages installed at the same 
+allow you to have multiple sets of Python packages installed at the same
 time, making reproducibility and upgrades easier. You can create,
 export, list, remove, and update environments that have different versions of
 Python and/or packages installed in them.*
@@ -115,11 +115,6 @@ To update the reported package with conda:
 Otherwise, to update with pip:
 
     (astropy-workshop) % pip install packagename --upgrade
-
-The exception to this is if the `astroquery` package is reported as
-out-of-date, always update to its pre-release version with pip:
-
-    (astropy-workshop) % pip install astroquery --pre --upgrade
 
 ## Additional Resources
 

--- a/00-Install_and_Setup/UPDATING.md
+++ b/00-Install_and_Setup/UPDATING.md
@@ -92,8 +92,7 @@ latest PyPI release using:
 
     (astropy-workshop) % pip install packagename --upgrade
 
-If you know you need the pre-release version from PyPI (e.g., `astroquery`),
-use:
+If you know you need the pre-release version from PyPI, use:
 
     (astropy-workshop) % pip install packagename --pre --upgrade
 

--- a/00-Install_and_Setup/environment.yml
+++ b/00-Install_and_Setup/environment.yml
@@ -29,5 +29,5 @@ dependencies:
     - "specutils>=0.5.1"
     - "glue-vispy-viewers>=0.6"
     - "glueviz>=0.9.1"
-    - astroquery
+    - "astroquery==0.3.9"
     - --pre


### PR DESCRIPTION
Pin `astroquery` as workaround for #83 . Might need a follow-up issue to unpin for future workshop.

Fixes #83 using workaround solution. With this patch:
```
(astropy-workshop) $ python check_env.py
Found IPython 7.9.0
Found cython 0.29.14
Found jupyter 
Found notebook 6.0.2
Found numpy 1.17.4
Found scipy 1.3.1
Found skimage 0.15.0
Found matplotlib 3.1.1
Found pandas 0.25.3
Found bs4 4.8.1
Found keyring 
Found html5lib 1.0.1
Found xlwt 1.3.0
Found requests 2.22.0
Found jupyterlab 2.0.0a1
Found astropy 4.0rc1
Found asdf 2.4.2
Found gwcs 0.11.0
Found photutils 0.7.1
Found specutils 0.6
Found glue_vispy_viewers 0.12.2
Found glue 0.15.6
Found astroquery 0.3.9

Your Python environment is good to go!
```

