### PR TITLE
Edits to Astropy Units, Quantities, and Constants

### DIFF
--- a/03-UnitsQuantities/Astropy_Units.ipynb
+++ b/03-UnitsQuantities/Astropy_Units.ipynb
@@ -1437,7 +1437,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Answer here (jWST and Sun)"
+    "# Answer here (JWST and Sun)"
    ]
   },
   {

--- a/03-UnitsQuantities/Astropy_Units.ipynb
+++ b/03-UnitsQuantities/Astropy_Units.ipynb
@@ -14,9 +14,31 @@
     "Astropy includes a powerful framework for units that allows users to attach units to scalars and arrays.  These quantities can be manipulated or combined, keeping track of the units.\n",
     "\n",
     "For more information about the features presented below, please see the\n",
-    "[astropy.units](http://docs.astropy.org/en/stable/units/index.html) docs.\n",
+    "[astropy.units](https://docs.astropy.org/en/stable/units/index.html) docs.\n",
     "\n",
-    "Also note that this tutorial assumes you have little or no knowledge of astropy units.  If you're moderately familiar with them and are interested in some more complex examples, you might instead prefer the Astropy tutoial on [\"Using Astropy Quantities for astrophysical calculations\"](http://www.astropy.org/astropy-tutorials/Quantities.html). (The file with that tutorial is also included next to this one.)"
+    "Also note that this tutorial assumes you have little or no knowledge of astropy units.  If you're moderately familiar with them and are interested in some more complex examples, you might instead prefer the Astropy tutorial on [\"Using Astropy Quantities for astrophysical calculations\"](http://learn.astropy.org/Quantities.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Table of contents:\n",
+    "\n",
+    "* <a href=\"#Representing-units\">Representing units</a>\n",
+    "* <a href=\"#Composite-units\">Composite units</a>\n",
+    "* <a href=\"#Quantity-objects\">Quantity objects</a>\n",
+    "* <a href=\"#Quantity-attributes\">Quantity attributes</a>\n",
+    "* <a href=\"#Quantity-arithmetic-operations\">Quantity arithmetic operations</a>\n",
+    "* <a href=\"#Combining-Quantities\">Combining Quantities</a>\n",
+    "* <a href=\"#Converting-units\">Converting units</a>\n",
+    "* <a href=\"#Decomposing-units\">Decomposing units</a>\n",
+    "* <a href=\"#Integration-with-Numpy-functions\">Integration with Numpy functions</a>\n",
+    "* <a href=\"#Defining-new-units\">Defining new units</a>\n",
+    "* <a href=\"#Using-physical-constants\">Using physical constants</a>\n",
+    "* <a href=\"#Equivalencies\">Equivalencies</a>\n",
+    "* <a href=\"#Putting-it-all-together:--A-simple-example\">Putting it all together: A simple example</a>\n",
+    "* <a href=\"#Exercises\">Exercises</a>"
    ]
   },
   {
@@ -40,6 +62,17 @@
    "outputs": [],
    "source": [
     "import astropy.units as u"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We will also import numpy here, which we use later.\n",
+    "# \"np\" is the common naming standard for this import.\n",
+    "import numpy as np"
    ]
   },
   {
@@ -164,7 +197,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# this is not defined\n",
+    "# This is undefined.\n",
     "u.inch"
    ]
   },
@@ -174,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# use this\n",
+    "# Use this instead.\n",
     "u.imperial.inch"
    ]
   },
@@ -258,14 +291,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "3.7 * u.au    # Quantity object"
+    "3.7 * u.au  # Quantity object"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A completely equivalent (but more verbose) way of doing the same thing is to use the `Quantity` object's initializer, demonstrated below.  In general, the simpler form (above) is preferred, as it is closer to how such a quantity would actually be written in text.  The initalizer form has more options, though, which you can learn about from the [astropy reference documentation on Quantity](http://docs.astropy.org/en/stable/api/astropy.units.quantity.Quantity.html)."
+    "A completely equivalent (but more verbose) way of doing the same thing is to use the `Quantity` object's initializer, demonstrated below.  In general, the simpler form (above) is preferred, as it is closer to how such a quantity would actually be written in text.  The initalizer form has more options, though, which you can learn about from the [astropy reference documentation on Quantity](https://docs.astropy.org/en/stable/api/astropy.units.quantity.Quantity.html)."
    ]
   },
   {
@@ -275,6 +308,15 @@
    "outputs": [],
    "source": [
     "u.Quantity(3.7, unit=u.au)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "u.Quantity(1 * u.cm, unit=u.m)"
    ]
   },
   {
@@ -290,17 +332,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# we need to import numpy, and the short-name \"np\" is the standard practice pretty much everywhere\n",
-    "import numpy as np"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x = np.array([1.2, 6.8, 3.7]) * u.pc / u.year\n",
+    "# We want to create the composite unit first, hence the parenthesis.\n",
+    "x = [1.2, 6.8, 3.7] * (u.pc / u.year)\n",
     "x"
    ]
   },
@@ -352,7 +385,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = np.array([1.2, 6.8, 3.7]) * u.pc / u.year\n",
+    "x = [1.2, 6.8, 3.7] * (u.pc / u.year)\n",
     "x"
    ]
   },
@@ -378,7 +411,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## `Quantity` Arithmetic Operations\n",
+    "## `Quantity` arithmetic operations\n",
     "\n",
     "\"`*`\" (multiplication), \"`/`\" (division), and \"`**`\" (power) operations can be performed on `Quantity` objects with `float`/`int` values."
    ]
@@ -389,7 +422,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q = 3.1 * u.km\n",
+    "q = 3.1 * u.km"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "q * 2"
    ]
   },
@@ -400,6 +441,15 @@
    "outputs": [],
    "source": [
     "q / 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "1 / q"
    ]
   },
   {
@@ -426,7 +476,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q1 = 3. * u.m / u.s\n",
+    "q1 = 3. * (u.m / u.s)\n",
     "q1"
    ]
   },
@@ -436,7 +486,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q2 = 5. * u.cm / u.s / u.g**2\n",
+    "q2 = 5. * (u.cm / u.s / u.g**2)\n",
     "q2"
    ]
   },
@@ -455,7 +505,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q1 / q2    # note the \"second\" unit cancelled out"
+    "q1 / q2  # Note the \"second\" unit cancelled out."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sometimes, one more step needed for \"clean\" output unit.\n",
+    "# Also see: Decomposing units (below)\n",
+    "(q1 / q2).to(u.g ** 2)"
    ]
   },
   {
@@ -473,8 +534,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = np.array([1.2, 6.8, 3.7]) * u.pc / u.year\n",
-    "x * 3    # elementwise multiplication"
+    "x = [1.2, 6.8, 3.7] * (u.pc / u.year)\n",
+    "x * 3  # Element-wise multiplication."
    ]
   },
   {
@@ -490,7 +551,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Add two quantities\n",
+    "# Add two quantities.\n",
     "(3 * u.m) + (5 * u.m)"
    ]
   },
@@ -518,7 +579,7 @@
    },
    "outputs": [],
    "source": [
-    "# this will fail because the units are not compatible\n",
+    "# This will fail because the units are incompatible.\n",
     "(3 * u.km) + (5. * u.km / u.s)"
    ]
   },
@@ -526,7 +587,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Coverting units\n",
+    "## Converting units\n",
     "\n",
     "Units can be converted to other equivalent units."
    ]
@@ -547,6 +608,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Convert year to seconds.\n",
     "q.to(u.s)"
    ]
   },
@@ -556,6 +618,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Convert degree squared to steradian.\n",
     "(7. * u.deg**2).to(u.sr)"
    ]
   },
@@ -565,28 +628,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Convert mph to kph.\n",
     "(55. * u.imperial.mile / u.h).to(u.km / u.h)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "q1 = 3. * u.m / u.s\n",
-    "q2 = 5. * u.cm / u.s / u.g**2\n",
-    "\n",
-    "q1 * q2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "(q1 * q2).to(u.m**2 / u.kg**2 / u.s**2)"
    ]
   },
   {
@@ -642,7 +685,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q = 8. * u.cm * u.pc / u.g / u.year**2\n",
+    "q = 8. * (u.cm * u.pc / u.g / u.year**2)\n",
     "q"
    ]
   },
@@ -720,7 +763,7 @@
    "outputs": [],
    "source": [
     "x = q.decompose()\n",
-    "x    # this is a \"dimensionless\" Quantity"
+    "x  # This is a \"dimensionless\" Quantity."
    ]
   },
   {
@@ -743,7 +786,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Most [Numpy](http://www.numpy.org) functions understand `Quantity` objects:"
+    "Most [Numpy](https://www.numpy.org) functions understand `Quantity` objects:"
    ]
   },
   {
@@ -752,7 +795,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.sin(30)    # np.sin assumes the input is in radians"
+    "np.sin(30)  # np.sin assumes the input is in radians."
    ]
   },
   {
@@ -761,7 +804,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.sin(30 * u.degree)    # awesome!"
+    "np.sin(30 * u.degree)  # Awesome!"
    ]
   },
   {
@@ -770,7 +813,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q = 100 * u.kg * u.kg\n",
+    "q = 100 * (u.kg * u.kg)\n",
     "np.sqrt(q)"
    ]
   },
@@ -797,7 +840,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Some numpy ufuncs require dimensionless quantities."
+    "Some Numpy \"ufuncs\" (universal functions) require dimensionless quantities."
    ]
   },
   {
@@ -806,7 +849,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.log10(4 * u.m)    # this doesn't make sense"
+    "np.log10(4 * u.m)  # This is not possible."
    ]
   },
   {
@@ -815,7 +858,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.log10(4 * u.m / (4 * u.km))    # note the units cancelled"
+    "np.log10(4 * u.m / (4 * u.km))  # Note that the units cancelled."
    ]
   },
   {
@@ -865,11 +908,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Important Note:**  In-place array operations do not work with units.\n",
-    "\n",
-    "For `numpy < 0.13` this example will silently drop the units.\n",
-    "\n",
-    "For `numpy >= 0.13` this example will raise an error. "
+    "**Important Note:**  In-place array operations do not work with units."
    ]
   },
   {
@@ -879,8 +918,7 @@
    "outputs": [],
    "source": [
     "a = np.arange(10.)\n",
-    "a *= 1.0 * u.kg    # in-place operator\n",
-    "a"
+    "a *= 1.0 * u.kg  # In-place operator will fail."
    ]
   },
   {
@@ -914,7 +952,7 @@
     "* np.choose\n",
     "* np.vectorize\n",
     "\n",
-    "See [Quantity Known Issues](http://docs.astropy.org/en/stable/known_issues.html#quantities-lose-their-units-with-some-operations) for more details."
+    "See [Quantity Known Issues](https://docs.astropy.org/en/stable/known_issues.html#quantities-lose-their-units-with-some-operations) for more details."
    ]
   },
   {
@@ -948,7 +986,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "(1. * u.yr).to(sol)    # 1 Earth year in Martian sol units"
+    "(1. * u.yr).to(sol)  # 1 Earth year in Martian sol units."
    ]
   },
   {
@@ -964,7 +1002,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pirate_ninja = u.def_unit('☠️👤', 1.0 * u.kW * u.hr / sol)"
+    "pirate_ninja = u.def_unit('☠️👤', 1.0 * (u.kW * u.hr / sol))"
    ]
   },
   {
@@ -982,7 +1020,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Mars oxygenator power requirement for 6 people\n",
+    "# Mars oxygenator power requirement for 6 people.\n",
     "(44.1 * pirate_ninja).to(u.W)"
    ]
   },
@@ -997,7 +1035,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [astropy.constants](http://docs.astropy.org/en/stable/constants/index.html) module contains physical constants relevant for astronomy.  They are defined as ``Quantity`` objects using the ``astropy.units`` framework."
+    "The [astropy.constants](https://docs.astropy.org/en/stable/constants/index.html) module contains physical constants relevant for astronomy.  They are defined as ``Quantity`` objects using the ``astropy.units`` framework.\n",
+    "\n",
+    "Please see the complete list of [available physical constants](https://docs.astropy.org/en/stable/constants/index.html#module-astropy.constants).  Additions are welcome!"
    ]
   },
   {
@@ -1006,8 +1046,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.constants import G, c, R_earth\n",
-    "G"
+    "from astropy import constants as const"
    ]
   },
   {
@@ -1016,7 +1055,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "c"
+    "const.G"
    ]
   },
   {
@@ -1025,7 +1064,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "R_earth"
+    "const.c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "const.L_sun"
    ]
   },
   {
@@ -1041,14 +1089,63 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "R_earth.to(u.km)"
+    "const.L_sun.to(u.erg / u.s)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Please see the complete list of [available physical constants](http://docs.astropy.org/en/stable/constants/index.html#module-astropy.constants).  Additions are welcome!"
+    "Also note that even constants are not constant. `astropy.constants` supports [different versions](https://docs.astropy.org/en/stable/constants/index.html#collections-of-constants-and-prior-versions)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import astropy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "astropy.physical_constants.get()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "astropy.astronomical_constants.get()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.constants import iau2012\n",
+    "iau2012.L_sun"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Changing the entire science state like this after\n",
+    "# imports is currently not possible, see\n",
+    "# https://github.com/astropy/astropy/issues/8781\n",
+    "astropy.astronomical_constants.set('iau2012')"
    ]
   },
   {
@@ -1066,7 +1163,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.constants import m_p  # proton mass"
+    "from astropy.constants import m_p  # Proton mass"
    ]
   },
   {
@@ -1075,7 +1172,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# this raises an error because mass and energy are different units\n",
+    "# This raises an error because mass and energy are different units.\n",
     "(m_p).to(u.eV)"
    ]
   },
@@ -1085,7 +1182,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# this succeeds, using equivalencies\n",
+    "# This succeeds using equivalencies.\n",
     "(m_p).to(u.MeV, u.mass_energy())"
    ]
   },
@@ -1093,7 +1190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This concept extends further in `astropy.units` to include some common practical astronomy situations where the units have no direct physical connection, but it is often useful to have a \"quick shorthand\".  For example, astronomical spectra are often given as a function of wavelength, frequency, or even energy of the photon.  For example, suppose you want to find the Lyman-limit wavelength:"
+    "This concept extends further in `astropy.units` to include some common practical astronomy situations where the units have no direct physical connection, but it is often useful to have a \"quick shorthand\".  For example, astronomical spectra are often given as a function of wavelength, frequency, or even energy of the photon.  For example, suppose you want to find the [Lyman-limit](https://en.wikipedia.org/wiki/Lyman_limit) wavelength:"
    ]
   },
   {
@@ -1104,7 +1201,7 @@
    },
    "outputs": [],
    "source": [
-    "# this raises an error\n",
+    "# This raises an error.\n",
     "(13.6 * u.eV).to(u.Angstrom)"
    ]
   },
@@ -1146,6 +1243,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Now back to Lyman-limit.\n",
     "(13.6 * u.eV).to(u.Angstrom, equivalencies=u.spectral())"
    ]
   },
@@ -1153,7 +1251,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Or if you remember the 21cm HI line, but can't remember the frequency, you could do:"
+    "Or if you remember the 21cm HI line, but cannot remember the frequency, you could do:"
    ]
   },
   {
@@ -1169,7 +1267,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To go one step further, the units of a spectrum's *flux* are further complicated by being dependent on the units of the spectrum's \"x-axis\" (i.e., $f_{\\lambda}$ for flux per unit wavelength or $f_{\\nu}$ for flux per unit frequency).  `astropy.units` supports this use case, but it is necessary to supply the location in the spectrum where the conversion is done:"
+    "To go one step further, the units of a spectrum's *flux* are further complicated by being dependent on the units of the spectrum's \"X-axis\" (i.e., $f_{\\lambda}$ for flux per unit wavelength or $f_{\\nu}$ for flux per unit frequency).  `astropy.units` supports this use case, but it is necessary to supply the location in the spectrum where the conversion is done:"
    ]
   },
   {
@@ -1178,7 +1276,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q = (1e-18 * u.erg / u.s / u.cm**2 / u.AA)\n",
+    "q = 1e-18 * (u.erg / u.s / u.cm**2 / u.AA)\n",
     "q"
    ]
   },
@@ -1195,21 +1293,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There's a lot of flexibility with equivalencies, including a variety of other useful built-in equivalencies.  So if you want to know more, you might want to check out the [equivalencies narrative documentation](http://docs.astropy.org/en/stable/units/equivalencies.html) or the [astropy.units.equivalencies reference docs](http://docs.astropy.org/en/stable/units/index.html#module-astropy.units.equivalencies)."
+    "There's a lot of flexibility with equivalencies, including a variety of other useful built-in equivalencies.  So if you want to know more, you might want to check out the [equivalencies narrative documentation](https://docs.astropy.org/en/stable/units/equivalencies.html) or the [astropy.units.equivalencies reference docs](https://docs.astropy.org/en/stable/units/index.html#module-astropy.units.equivalencies)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Putting it all together"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## A simple example\n",
+    "# Putting it all together:  A simple example\n",
     "\n",
     "Let's estimate the (circular) orbital speed of the Earth around the Sun using Kepler's Law:\n",
     "\n",
@@ -1222,8 +1313,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.constants import G\n",
-    "v = np.sqrt(G * 1 * u.M_sun / (1 * u.au))\n",
+    "v = np.sqrt(const.G * 1 * u.M_sun / (1 * u.au))\n",
     "v"
    ]
   },
@@ -1242,7 +1332,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "v.decompose()    # remember the default uses SI bases"
+    "v.decompose()  # Remember that the default uses SI bases"
    ]
   },
   {
@@ -1267,6 +1357,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Exercises\n",
+    "\n",
     "## Exercise 1\n",
     "\n",
     "The *James Webb Space Telescope (JWST)* will be located at the second Sun-Earth Lagrange (L2) point:\n",
@@ -1284,9 +1376,9 @@
     "\n",
     "*Hints*:\n",
     "\n",
-    "* $M_{earth}$ and $M_{sun}$ are defined [constants](http://docs.astropy.org/en/stable/constants/#reference-api) \n",
+    "* $M_{earth}$ and $M_{sun}$ are defined [constants](https://docs.astropy.org/en/stable/constants/#reference-api) \n",
     "\n",
-    "* the mile unit is defined as ``u.imperial.mile`` (see [imperial units](http://docs.astropy.org/en/v0.2.1/units/index.html#module-astropy.units.imperial))"
+    "* the mile unit is defined as ``u.imperial.mile`` (see [imperial units](https://docs.astropy.org/en/v0.2.1/units/index.html#module-astropy.units.imperial))"
    ]
   },
   {
@@ -1299,7 +1391,7 @@
    },
    "outputs": [],
    "source": [
-    "# answer here (km)"
+    "# Answer here (km)"
    ]
   },
   {
@@ -1308,7 +1400,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# answer here (mile)"
+    "# Answer here (mile)"
    ]
   },
   {
@@ -1336,7 +1428,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# answer here (Earth)"
+    "# Answer here (JWST and Earth)"
    ]
   },
   {
@@ -1345,7 +1437,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# answer here (Sun)"
+    "# Answer here (jWST and Sun)"
    ]
   },
   {
@@ -1354,11 +1446,13 @@
    "source": [
     "## Exercise 3\n",
     "\n",
-    "Calculate the Schwarzschild radius in units of solar radii of the Sgr A*, the Milky Way's supermassive black hole with $M = 4.31 \\times 10^6 M_\\odot$, given\n",
+    "Calculate the [Schwarzschild radius](https://en.wikipedia.org/wiki/Schwarzschild_radius) in units of solar radii of the Sgr A*, the Milky Way's supermassive black hole with $M = 4.31 \\times 10^6 M_\\odot$, given\n",
     "\n",
     "$$r_\\mathrm{s} = \\frac{2 G M}{c^2}$$\n",
     "\n",
-    "Also calculate the angular size of the event horizon on the sky in microarcseconds, given the distance to the galactic center $d_{center} = 7.94$ kpc."
+    "Also calculate the angular size of the event horizon on the sky in microarcseconds, given the distance to the galactic center $d_{center} = 7.94$ kpc, given\n",
+    "\n",
+    "$$\\theta = \\mathrm{arctan}\\frac{2 r_\\mathrm{s}}{d_{center}}$$"
    ]
   },
   {
@@ -1367,7 +1461,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# answer radius here"
+    "# Answer radius here"
    ]
   },
   {
@@ -1376,116 +1470,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# answer angular size here"
+    "# Answer angular size here"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Advanced Example: little *h*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For this example, we'll consider how to support the practice of defining units in terms of the dimensionless Hubble constant $h=h_{100}=\\frac{H_0}{100 \\, {\\rm km/s/Mpc}}$."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We use the name 'h100' to differentiate from \"h\" as in \"hours\"."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# define the h100 and h70 units\n",
-    "h100 = u.def_unit(['h100'])\n",
-    "h70 = u.def_unit('h70', h100 * 100. / 70)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# add as equivalent units\n",
-    "u.add_enabled_units([h100, h70])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "h100.find_equivalent_units()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Define the Hubble constant ($H_0$) in terms of ``h100``:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "H = 100 * h100 * u.km / u.s / u.Mpc\n",
-    "H"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now compute the Hubble time ($1 / H_0$) for h = h100 = 1:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "t_H = (1/H).to(u.Gyr / h100)\n",
-    "t_H"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "and for h = 0.7:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "t_H.to(u.Gyr / h70)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -1505,7 +1491,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/03-UnitsQuantities/Astropy_Units.ipynb
+++ b/03-UnitsQuantities/Astropy_Units.ipynb
@@ -37,6 +37,7 @@
     "* <a href=\"#Defining-new-units\">Defining new units</a>\n",
     "* <a href=\"#Using-physical-constants\">Using physical constants</a>\n",
     "* <a href=\"#Equivalencies\">Equivalencies</a>\n",
+    "* <a href=\"#Performance-consideration\">Performance consideration</a>\n",
     "* <a href=\"#Putting-it-all-together:--A-simple-example\">Putting it all together: A simple example</a>\n",
     "* <a href=\"#Exercises\">Exercises</a>"
    ]
@@ -1294,6 +1295,72 @@
    "metadata": {},
    "source": [
     "There's a lot of flexibility with equivalencies, including a variety of other useful built-in equivalencies.  So if you want to know more, you might want to check out the [equivalencies narrative documentation](https://docs.astropy.org/en/stable/units/equivalencies.html) or the [astropy.units.equivalencies reference docs](https://docs.astropy.org/en/stable/units/index.html#module-astropy.units.equivalencies)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Performance consideration\n",
+    "\n",
+    "For more details on performance on big dataset, see [units performance tips](https://docs.astropy.org/en/stable/units/index.html#performance-tips).\n",
+    "\n",
+    "When working with a big data array, the `<<` operator can be used to speed up Quantity initialization. Let's consider this array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "big_array = np.random.random(10_000_000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Defining the Quantity the simplest way without parenthesis.\n",
+    "%timeit big_array * u.m / u.s / u.kg / u.sr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Defining the Quantity with the * operator and parenthesis.\n",
+    "%timeit big_array * (u.m / u.s / u.kg / u.sr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Defining the Quantity with the << operator (parenthesis not needed).\n",
+    "%timeit big_array << u.m / u.s / u.kg / u.sr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Replace the Quantity values below with your slow/fast timing to see how much things sped up on your machine. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "((89.4 * u.ms) / (67.1 * u.us)).to(u.dimensionless_unscaled)"
    ]
   },
   {

--- a/03-UnitsQuantities/Astropy_Units_Solutions.ipynb
+++ b/03-UnitsQuantities/Astropy_Units_Solutions.ipynb
@@ -37,65 +37,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "import astropy.units as u"
+    "import astropy.units as u\n",
+    "from astropy import constants as const"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "slideshow": {
      "slide_type": "-"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$1496555.1 \\; \\mathrm{km}$"
-      ],
-      "text/plain": [
-       "<Quantity 1496555.0858807534 km>"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "d_earth = u.au * (1. * u.M_earth / (3. * u.M_sun))**(1./3)\n",
+    "d_earth = u.au * (1. * const.M_earth / (3. * const.M_sun))**(1./3)\n",
     "d_earth.to(u.km)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$929916.22 \\; \\mathrm{mi}$"
-      ],
-      "text/plain": [
-       "<Quantity 929916.2179625693 mi>"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "d_earth.to(u.imperial.mile)"
    ]
@@ -121,65 +89,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.constants import G"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$1.1571336 \\; \\mathrm{N}$"
-      ],
-      "text/plain": [
-       "<Quantity 1.157133562380145 N>"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "F = (G * 1. * u.M_earth * 6500. * u.kg) / d_earth**2\n",
+    "m_JWST = 6500. * u.kg\n",
+    "F = (const.G * const.M_earth * m_JWST) / d_earth**2\n",
     "F.to(u.N)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$37.796265 \\; \\mathrm{N}$"
-      ],
-      "text/plain": [
-       "<Quantity 37.796264500778264 N>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "d_sun = d_earth + 1. * u.au\n",
-    "F = (G * 1. * u.M_sun * 6500. * u.kg) / d_sun**2\n",
+    "F = (const.G * const.M_sun * m_JWST) / d_sun**2\n",
     "F.to(u.N)"
    ]
   },
@@ -193,55 +119,9 @@
     "\n",
     "$$r_\\mathrm{s} = \\frac{2 G M}{c^2}$$\n",
     "\n",
-    "Also calculate the angular size of the event horizon on the sky in microarcseconds, given the distance to the galactic center $d_{center} = 7.94$ kpc."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Schwarzschild radius = 18.295972154652976 solRad\n"
-     ]
-    }
-   ],
-   "source": [
-    "import astropy.units as u\n",
-    "from astropy.constants import c\n",
+    "Also calculate the angular size of the event horizon on the sky in microarcseconds, given the distance to the galactic center $d_{center} = 7.94$ kpc, given\n",
     "\n",
-    "# Schwarzschild radius:\n",
-    "r_s = 2*G*4.31e6*u.Msun/c**2\n",
-    "print(\"Schwarzschild radius = {0}\".format(r_s.to(u.Rsun)))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$21.431944 \\; \\mathrm{\\mu arcsec}$"
-      ],
-      "text/plain": [
-       "<Quantity 21.43194446 uarcsec>"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Size on the sky given small angle approximation\n",
-    "sgr_a_distance = 7940 * u.pc\n",
-    "angular_diameter = np.arctan(2*r_s/sgr_a_distance)\n",
-    "angular_diameter.to(u.uarcsec)"
+    "$$\\theta = \\mathrm{arctan}\\frac{2 r_\\mathrm{s}}{d_{center}}$$"
    ]
   },
   {
@@ -249,7 +129,25 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Schwarzschild radius:\n",
+    "bh_mass = 4.31e6 * u.Msun\n",
+    "r_s = 2 * const.G * bh_mass / const.c**2\n",
+    "print(\"Schwarzschild radius = \", r_s.to(u.Rsun))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Size on the sky given small angle approximation\n",
+    "import numpy as np\n",
+    "sgr_a_distance = 7940 * u.pc\n",
+    "angular_diameter = np.arctan(2 * r_s / sgr_a_distance)\n",
+    "angular_diameter.to(u.uarcsec)"
+   ]
   }
  ],
  "metadata": {
@@ -269,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changes to the "Astropy Units, Quantities, and Constants" section include but not limited to:

* Adding a table of contents to show you that there is more materials that 30 minutes can possibly cover, especially if including the PDF slides (9 pages) beforehand.
* Added new materials for constants science state.
* Completely removed the "little h" example at the end, as we won't have time for it anyway.
* Clarified the formula for Exercise 3 Part 2. (This is an Astropy workshop, not an astronomy test.)
* Grammatical fixes.
* Minor code clean-ups.