### PR TITLE
No longer needs astropy 4.0rc

### DIFF
--- a/00-Install_and_Setup/environment.yml
+++ b/00-Install_and_Setup/environment.yml
@@ -23,7 +23,7 @@ dependencies:
     - xlwt
     - requests
     - jupyterlab
-    - "astropy>=4.0rc1"
+    - "astropy>=4.0"
     - asdf
     - "gwcs>=0.10"
     - "photutils>=0.7.2"


### PR DESCRIPTION
I think... Tagging Adrian just to make sure the CI failures are expected.