### PR TITLE
MNT: Clean-up README files to be more consistent

### DIFF
--- a/01-IntroCoC/README.md
+++ b/01-IntroCoC/README.md
@@ -1,0 +1,3 @@
+### Introduction and Code of Conduct
+
+**Author**:  Unknown

--- a/01-IntroCoC/README.md
+++ b/01-IntroCoC/README.md
@@ -1,3 +1,3 @@
 ### Introduction and Code of Conduct
 
-**Author**:  Unknown
+**Authors**: Erik Tollerud & Kelle Cruz

--- a/03-UnitsQuantities/README.md
+++ b/03-UnitsQuantities/README.md
@@ -1,3 +1,4 @@
 ### Astropy Units, Quantities, and Constants
 
-**Author**: Larry Bradley
+**Authors**: Larry Bradley, , Pey Lian Lim, Juan Cabanela, David Shupe,
+Kelle Cruz, Adrian Price-Whelan, & Brett Morris

--- a/03-UnitsQuantities/README.md
+++ b/03-UnitsQuantities/README.md
@@ -1,5 +1,3 @@
 ### Astropy Units, Quantities, and Constants
 
-**Instructor**: Pey Lian Lim
-
 **Author**: Larry Bradley

--- a/04-Coordinates/README.md
+++ b/04-Coordinates/README.md
@@ -1,3 +1,3 @@
 ### Astropy Coordinates
 
-**Author**:  Unknown
+**Authors**: Erik Tollerud & Adrian Price-Whelan

--- a/04-Coordinates/README.md
+++ b/04-Coordinates/README.md
@@ -1,3 +1,3 @@
 ### Astropy Coordinates
 
-**Instructor**:  Adrian Price-Whelan
+**Author**:  Unknown

--- a/05-FITS/README.md
+++ b/05-FITS/README.md
@@ -1,5 +1,3 @@
 ### I/O: FITS and ASCII
 
-**Instructor**:  Pey Lian Lim
-
 **Authors**: Lía Corrales & Lauren Chambers

--- a/06-Tables/README.md
+++ b/06-Tables/README.md
@@ -1,5 +1,3 @@
 ### Astropy Tables
 
-**Instructor**:  Brigitta Sipocz
-
-**Authors**: Tim Pickering, Tom Aldcroft
+**Authors**: Tim Pickering & Tom Aldcroft

--- a/07-Models/README.md
+++ b/07-Models/README.md
@@ -1,3 +1,3 @@
-### WCS and Images
+### Modeling
 
 **Author**:  Unknown

--- a/07-Models/README.md
+++ b/07-Models/README.md
@@ -1,3 +1,3 @@
 ### Modeling
 
-**Author**:  Unknown
+**Authors**: Erik Tollerud & Adrian Price-Whelan

--- a/08-WCS/README.md
+++ b/08-WCS/README.md
@@ -1,3 +1,3 @@
 ### WCS and Images
 
-**Author**:  Unknown
+**Authors**: Megan Sosey, Juan Cabanela, & Adrian Price-Whelan

--- a/09-Photutils/README.md
+++ b/09-Photutils/README.md
@@ -1,5 +1,3 @@
 ### Photutils
 
-**Instructor**:  Clare Shanahan
-
 **Authors**: Larry Bradley & Lauren Chambers

--- a/09b-Specutils/README.md
+++ b/09b-Specutils/README.md
@@ -1,5 +1,3 @@
 ### Specutils
 
-**Instructor**:  Erik Tollerud
-
 **Author**: Erik Tollerud

--- a/10-WrapUp/README.md
+++ b/10-WrapUp/README.md
@@ -1,3 +1,3 @@
-### WCS and Images
+### Wrap-Up
 
 **Author**:  Unknown

--- a/10-WrapUp/README.md
+++ b/10-WrapUp/README.md
@@ -1,3 +1,3 @@
 ### Wrap-Up
 
-**Author**:  Unknown
+**Author**: Erik Tollerud & Kelle Cruz

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This could take as long as *one hour* depending on your current configuration an
 DO NOT WAIT UNTIL THE DAY OF THE WORKSHOP.
 
 ## Schedule
-| Time              | Topic    | Presenter |
+| Time              | Topic    | Presenter/Instructor |
 |-------------------|----------|-----------|
 |**9:00** | **Continental Breakfast** | |
 |9:00 - 9:30    | [Install and config](00-Install_and_Setup) help, if needed  | All |


### PR DESCRIPTION
Fix #96 

* Add missing README files
* Remove instructors listing because they are already listed in root-level README
* Fill in missing authors as "unknown" -- If you know who they are, please comment on this PR or open follow-up PRs if this one is already merged