### PR TITLE
Add the contents of the day-before email to participants

### DIFF
--- a/00-Install_and_Setup/00_UPDATE_EMAIL.md
+++ b/00-Install_and_Setup/00_UPDATE_EMAIL.md
@@ -1,0 +1,60 @@
+Dear Astropy Workshop Participants,
+
+The workshop begins at 9:00am tomorrow! The room is 301B at the Hawai'i Convention Center (changed
+from our previous email).
+
+If you have not yet done so, please follow the setup instructions at
+
+https://github.com/astropy/astropy-workshop/blob/master/00-Install_and_Setup
+
+If you are having problems, please arrive promptly at 9:00am so we can help you before the presentations
+start at 9:30am.
+
+__Updating workshop materials__
+
+Our facilitators are polishing up workshop materials. To update the workshop notebooks, please follow
+these instructions:
+
+https://github.com/astropy/astropy-workshop/blob/master/00-Install_and_Setup/UPDATING.md
+
+It may be necessary to update just before the workshop begins. We expect those changes to be small and
+to not take long.
+
+__Schedule__
+
+https://github.com/astropy/astropy-workshop
+
+This workshop is sold out and we are anticipating folks to show up who did not pre-register. If you do not
+arrive by 10:30, your seat may be given away. If you know you're going to be late, please drop me an email.
+
+Continental breakfast will be available from 9-10:30 and there will be snacks and coffee again in the afternoon. Lunch will NOT be provided.
+
+__Slack Channel__
+
+http://astropy-slack-invite.herokuapp.com/
+
+Please join the #workshop channel in the Astropy slack.
+
+Looking forward to seeing you there!
+
+David Shupe, on behalf of the workshop team:
+
+_Facilitators_
+* Larry Bradley
+* Tom Donaldson
+* Rebecca Lange
+* Pey Lian Lim
+* Adrian Price-Whelan
+* Clare Shanahan
+* David Shupe
+* Brigitta Sipőcz
+* Erik Tollerud
+
+_Organizers and Contributors_
+* Lia Corrales
+* Kelle Cruz
+* Pey Lian Lim
+* Brett Morris
+* David Shupe
+* Erik Tollerud
+


### PR DESCRIPTION
Fixes #121 

Add the contents of the email to send to registered participants on 2020-Jan-03, the day before the workshop. Correct the room number to 301B. Refer to the updating instructions and note they may have to do it right before the workshop.