### PR TITLE
FITS header.remove with ignore_missing

### DIFF
--- a/05-FITS/io_fits_ascii_overview.ipynb
+++ b/05-FITS/io_fits_ascii_overview.ipynb
@@ -199,7 +199,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To delete a keyword/card, it is best to use the *remove* method, which does not raise an exception if the keyword is not present."
+    "To delete a keyword/card, it is best to use the *remove* method, which does not raise an exception if the keyword is not present and `ignore_missing=True` option is provided."
    ]
   },
   {
@@ -208,8 +208,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f[extnum].header.remove('NOBS')\n",
-    "f[extnum].header.remove('observer')"
+    "f[extnum].header.remove('NOBS', ignore_missing=True)\n",
+    "f[extnum].header.remove('observer', ignore_missing=True)"
    ]
   },
   {

--- a/05-FITS/io_fits_ascii_overview.ipynb
+++ b/05-FITS/io_fits_ascii_overview.ipynb
@@ -275,7 +275,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`scidata` is a pointer to the data array of the HDU. If it changes, the data in the HDU changes as well."
+    "`scidata` is a copy of the data array of the HDU. If it changes, it will not affect the data in the FITS file."
    ]
   },
   {


### PR DESCRIPTION
This fixes a bug in the FITS notebook, where `.remove` should not have raised an exception when header keyword is nonexistent.