### PR TITLE
TST: Revert to when Linux worked and disable Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,10 +49,8 @@ setup_conda_win: &setup_conda_win
 make_env: &make_env
   name: Make workshop environment
   command: |
-    conda init bash
-    source ~/.bashrc
     conda env create -n astropy-workshop --file 00-Install_and_Setup/environment.yml
-    conda activate astropy-workshop
+    source activate astropy-workshop
     pip install -r .circleci/dev-requirements.txt
     pip install git+https://github.com/adrn/nbstatic
     python -m ipykernel install --user --name astropy-workshop
@@ -60,14 +58,14 @@ make_env: &make_env
 execute_nb: &execute_nb
   name: Execute the notebooks
   command: |
-    conda activate astropy-workshop
+    source activate astropy-workshop
     which python
     python -m nbstatic execute .
 
 convert_nb: &convert_nb
   name: Convert the notebooks to HTML
   command: |
-    conda activate astropy-workshop
+    source activate astropy-workshop
     which python
     python -m nbstatic convert .
 
@@ -94,16 +92,17 @@ jobs:
       # TODO: note that this currently doesn't run because we don't have a paid
       # plan with circleci
 
-  test_windows:
-    executor:
-      name: win/default
-    steps:
-      - checkout
-      - *restore_cache
-      - run: *setup_conda_win
-      - run: *make_env
-      - *save_cache
-      - run: *execute_nb
+  # TODO: Re-enable if can fix source activate error.
+  #test_windows:
+  #  executor:
+  #    name: win/default
+  #  steps:
+  #    - checkout
+  #    - *restore_cache
+  #    - run: *setup_conda_win
+  #    - run: *make_env
+  #    - *save_cache
+  #    - run: *execute_nb
 
 workflows:
   version: 2
@@ -111,4 +110,4 @@ workflows:
     jobs:
       - test_linux
       # - test_macos
-      - test_windows
+      # - test_windows


### PR DESCRIPTION
CircleCI used to pass on Linux but failed on Windows. Attempting to fix Windows broke both. Due to lack of resources, let's just revert this back to when Linux used to work and completely disable Windows testing for now.

Fix #112 