### PR TITLE
update specutils version to 1.1.1

### DIFF
--- a/00-Install_and_Setup/environment.yml
+++ b/00-Install_and_Setup/environment.yml
@@ -31,5 +31,5 @@ dependencies:
     - asdf
     - "gwcs>=0.16"
     - "photutils>=1.0.1"
-    - "specutils>=1.0"
+    - "specutils>=1.1.1"
     - astroquery


### PR DESCRIPTION
I just pushed out a quick specutils 1.1.1 that addresses #155 .  This PR then closes #155 by updating to make that version a requirement for the workshop.

I'll add a follow-on PR that updates the content, since some of the workshop attendees will have already run the install instructions and need to update, but that's separate from this PRs immediate fix of #155