### PR TITLE
Update Photutils notebooks

### DIFF
--- a/00-Install_and_Setup/check_env.py
+++ b/00-Install_and_Setup/check_env.py
@@ -31,7 +31,7 @@ PKGS = {'IPython': '7.2',
         'asdf': None,
         'gwcs': '0.16',
         'ccdproc': '2.0',
-        'photutils': '1.0.1',
+        'photutils': '1.1.0',
         'specutils': '1.1.1',
         'astroquery': '0.4.1'}
 

--- a/00-Install_and_Setup/environment.yml
+++ b/00-Install_and_Setup/environment.yml
@@ -31,6 +31,6 @@ dependencies:
     - "astropy>=4.2"
     - asdf
     - "gwcs>=0.16"
-    - "photutils>=1.0.1"
+    - "photutils>=1.1.0"
     - "specutils>=1.1.1"
     - astroquery

--- a/09-Photutils/gaussian_psf_photometry.ipynb
+++ b/09-Photutils/gaussian_psf_photometry.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"data/photutils_banner.svg\" width=500 alt=\"Photutils logo\">"
+    "<img src=\"data/photutils_banner.svg\" width=500 alt=\"Photutils logo\" style=\"margin-left: 0;\">"
    ]
   },
   {
@@ -17,36 +17,28 @@
     "- Documentation: https://photutils.readthedocs.io/en/stable/\n",
     "- Issue Tracker:  https://github.com/astropy/photutils/issues\n",
     "\n",
-    "## Photutils capabilities:\n",
-    "\n",
-    "- Background and background noise estimation\n",
-    "- Source Detection and Extraction\n",
-    "  - DAOFIND and IRAF's starfind\n",
-    "  - Image segmentation\n",
-    "  - local peak finder\n",
-    "- Aperture photometry\n",
-    "- PSF photometry\n",
-    "- ePSF building\n",
-    "- PSF matching\n",
-    "- Centroids\n",
-    "- Morphological properties\n",
-    "- Elliptical isophote analysis\n",
-    "\n",
-    "\n",
-    "## In this additional notebook, we will review:\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<h2 style=\"margin-top: 0\">In this notebook, we will cover:</h2>\n",
     "\n",
     "- PSF photometry using simulated 2D Gaussian PSFs\n",
     "    - `BasicPSFPhotometry`\n",
     "    - `IterativelySubtractedPSFPhotometry`\n",
     "    - `DAOPhotPSFPhotometry`\n",
+    "</div>\n",
     "\n",
     "\n",
-    "---\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Point Spread Function Photometry with Photutils\n",
     "\n",
-    "The PSF photometry module of photutils is intended to be a fully modular tool such that users are able to completly customise the photometry procedure, e.g., by using different source detection algorithms, background estimators, PSF models, etc. Photutils provides implementations for each subtask involved in the photometry process, however, users are still able to include their own implementations without having to touch into the photutils core classes!\n",
+    "The PSF photometry module of `photutils` is intended to be a fully modular tool such that users are able to completely customize the photometry procedure, e.g., by using different source detection algorithms, background estimators, PSF models, etc. Photutils provides implementations for each subtask involved in the photometry process, however, users are still able to include their own implementations without having to touch into the photutils core classes!\n",
     "\n",
-    "This modularity characteristic is accomplished by using the object oriented programming approach which provides a more convient user experience while at the same time allows the developers to think in terms of classes and objects rather than isolated functions.\n",
+    "This modularity characteristic is accomplished by using the object oriented programming approach which provides a more convenient user experience while at the same time allows the developers to think in terms of classes and objects rather than isolated functions.\n",
     "\n",
     "Photutils provides three basic classes to perform PSF photometry: `BasicPSFPhotometry`, `IterativelySubtractedPSFPhotometry`, and `DAOPhotPSFPhotometry`. In this notebook, we will go through them, explaining their differences and particular uses."
    ]
@@ -153,7 +145,7 @@
     "%matplotlib inline\n",
     "from matplotlib import rcParams\n",
     "import matplotlib.pyplot as plt\n",
-    "rcParams['image.cmap'] = 'magma'\n",
+    "\n",
     "rcParams['image.aspect'] = 1  # to get images with square pixels\n",
     "rcParams['figure.figsize'] = (20,10)\n",
     "rcParams['image.interpolation'] = 'nearest'\n",
@@ -162,7 +154,7 @@
     "\n",
     "plt.imshow(image)\n",
     "plt.title('Simulated data')\n",
-    "plt.colorbar(orientation='horizontal', fraction=0.046, pad=0.04)"
+    "plt.colorbar(orientation='horizontal', fraction=0.046, pad=0.04);"
    ]
   },
   {
@@ -183,11 +175,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "BasicPSFPhotometry has the following mandatory attributes:\n",
-    "    * group_maker : callable or instance of any GroupStarsBase subclass\n",
-    "    * bkg_estimator : callable, instance of any BackgroundBase subclass, or None\n",
-    "    * psf_model : astropy.modeling.Fittable2DModel instance\n",
-    "    * fitshape : integer or length-2 array-like"
+    "`BasicPSFPhotometry` has the following mandatory attributes:\n",
+    "\n",
+    "* group_maker : callable or instance of any `GroupStarsBase` subclass\n",
+    "* bkg_estimator : callable, instance of any `BackgroundBase` subclass, or None\n",
+    "* psf_model : `astropy.modeling.Fittable2DModel` instance\n",
+    "* fitshape : integer or length-2 array-like"
    ]
   },
   {
@@ -195,9 +188,10 @@
    "metadata": {},
    "source": [
     "And the following optional attributes:\n",
-    "    * finder : callable or instance of any StarFinderBase subclasses or None\n",
-    "    * fitter : Astropy Fitter instance\n",
-    "    * aperture_radius : float or int"
+    "\n",
+    "* finder : callable or instance of any `StarFinderBase` subclasses or None\n",
+    "* fitter : Astropy Fitter instance\n",
+    "* aperture_radius : float or int"
    ]
   },
   {
@@ -211,7 +205,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`group_maker` can be instantiated using any GroupStarBase subclass, such as `photutils.psf.DAOGroup` or `photutils.psf.DBSCANGroup`, or even using a `callable` provided by the user."
+    "`group_maker` can be instantiated using any `GroupStarBase` subclass, such as `photutils.psf.DAOGroup` or `photutils.psf.DBSCANGroup`, or even using a `callable` provided by the user."
    ]
   },
   {
@@ -219,7 +213,8 @@
    "metadata": {},
    "source": [
     "`photutils.psf.DAOGroup` is a class which implements the `GROUP` algorithm proposed by Stetson which is used in DAOPHOT. This class takes one attribute to be initialized namely:\n",
-    "    * crit_separation : int or float\n",
+    "\n",
+    "* crit_separation : int or float\n",
     "    Distance, in units of pixels, such that any two stars separated by less than this distance will be placed in the same group."
    ]
   },
@@ -248,7 +243,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's instantiate a `group_maker` from `DAOGroup`:"
+    "Now, let's instantiate a `group_maker` from `DAOGroup`."
    ]
   },
   {
@@ -302,14 +297,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The user is welcome to refer to the Background Esimation narrative docs in the photutils webpage for a detailed explanation. https://photutils.readthedocs.io/en/stable/background.html"
+    "The user is welcome to refer to the [Background Estimation narrative docs](https://photutils.readthedocs.io/en/stable/background.html) in the photutils webpage for a detailed explanation."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook, we will use the class `MMMBackground` which is intended to estimate scalar background. This class is based on the background estimator used in `DAOPHOT`."
+    "In this notebook, we will use the class `MMMBackground` that is intended to estimate scalar background. This class is based on the background estimator used in `DAOPHOT`."
    ]
   },
   {
@@ -325,7 +320,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from photutils import MMMBackground\n",
+    "from photutils.background import MMMBackground\n",
+    "\n",
     "mmm_bkg = MMMBackground()"
    ]
   },
@@ -375,6 +371,7 @@
    "outputs": [],
    "source": [
     "from photutils.psf import IntegratedGaussianPRF\n",
+    "\n",
     "gaussian_psf = IntegratedGaussianPRF(sigma=2.0)"
    ]
   },
@@ -397,25 +394,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The finder attribute is used to perform source detection. It can be any subclass of `photutils.StarFinderBase` such as `photutils.DAOStarFinder` or `photutils.IRAFStarFinder`, which implement a DAOPHOT-like or IRAF-like source detection algorithms, respectively. The user can also set her/his own source detection algorithm as long as the input/output formats are compatible with `photutils.StarFinderBase`."
+    "The finder attribute is used to perform source detection. It can be any subclass of `StarFinderBase` such as `DAOStarFinder` or `IRAFStarFinder`, which implement a DAOPHOT-like or IRAF-like source detection algorithms, respectively. The user can also set her/his own source detection algorithm as long as the input/output formats are compatible with `StarFinderBase`."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`photutils.DAOStarFinder`, for instance, receives the following mandatory attributes: \n",
-    "    * threshold : float\n",
-    "        The absolute image value above which to select sources.\n",
-    "    * fwhm : float\n",
-    "        The full-width half-maximum (FWHM) of the major axis of the Gaussian kernel in units of pixels."
+    "`DAOStarFinder`, for instance, receives the following mandatory attributes: \n",
+    "    \n",
+    "* threshold : float\n",
+    "  The absolute image value above which to select sources.\n",
+    "        \n",
+    "* fwhm : float\n",
+    "  The full-width half-maximum (FWHM) of the major axis of the Gaussian kernel in units of pixels."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's instantiate our `DAOStarFinder` object:"
+    "Now, let's instantiate our `DAOStarFinder` object."
    ]
   },
   {
@@ -499,7 +498,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The aperture radius corresponds to the radius used to compute initial guesses for the fluxes of the sources. If this value is `None`, then one fwhm will be used if it can be determined by the `psf_model`."
+    "The aperture radius corresponds to the radius used to compute initial guesses for the fluxes of the sources. If this value is `None`, then one FWHM will be used if it can be determined by the `psf_model`."
    ]
   },
   {
@@ -523,6 +522,7 @@
    "outputs": [],
    "source": [
     "from photutils.psf import BasicPSFPhotometry\n",
+    "\n",
     "basic_photometry = BasicPSFPhotometry(group_maker=daogroup, bkg_estimator=mmm_bkg,\n",
     "                                      psf_model=gaussian_psf, fitshape=fitshape,\n",
     "                                      finder=daofinder)"
@@ -581,7 +581,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's use the `IRAFStarFinder` and play with the optional parameters. A complete description of these parameters can be seen at the `photutils.dection` API documentation: https://photutils.readthedocs.io/en/stable/api/photutils.detection.IRAFStarFinder.html#photutils.detection.IRAFStarFinder"
+    "Let's use the `IRAFStarFinder` and play with the optional parameters. A complete description of these parameters can be seen at the `photutils.detection` API documentation: https://photutils.readthedocs.io/en/stable/api/photutils.detection.IRAFStarFinder.html#photutils.detection.IRAFStarFinder"
    ]
   },
   {
@@ -591,6 +591,7 @@
    "outputs": [],
    "source": [
     "from photutils.detection import IRAFStarFinder\n",
+    "\n",
     "iraffind = IRAFStarFinder(threshold=2.5*mmm_bkg(image),\n",
     "                          fwhm=sigma_psf*gaussian_sigma_to_fwhm,\n",
     "                          minsep_fwhm=0.01, roundhi=5.0, roundlo=-5.0,\n",
@@ -675,6 +676,7 @@
    "outputs": [],
    "source": [
     "from astropy.table import Table\n",
+    "\n",
     "positions = Table(names=['x_0', 'y_0'], data=[starlist['x_mean'], starlist['y_mean']])"
    ]
   },
@@ -804,6 +806,7 @@
    "outputs": [],
    "source": [
     "from photutils.psf import IterativelySubtractedPSFPhotometry\n",
+    "\n",
     "itr_phot = IterativelySubtractedPSFPhotometry(group_maker=daogroup, bkg_estimator=mmm_bkg,\n",
     "                                              psf_model=gaussian_psf, fitshape=fitshape,\n",
     "                                              finder=iraffind, niters=2)"
@@ -813,7 +816,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's now perform photometry on our artificil image:"
+    "Let's now perform photometry on our artificial image:"
    ]
   },
   {
@@ -914,8 +917,7 @@
     "\n",
     "Near future implementations in the photutils.psf module include:\n",
     "\n",
-    "* FWHM estimation: a Python equivalent to DAOPHOT psfmeasure.\n",
-    "* Uncertainties computation: uncertainties are very critical and it's very likely that we are going to use astropy saba package to integrate uncertainty computation into photutils.psf."
+    "* FWHM estimation: a Python equivalent to DAOPHOT psfmeasure."
    ]
   }
  ],
@@ -936,7 +938,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,

--- a/09-Photutils/image_psf_photometry_withNIRCam.ipynb
+++ b/09-Photutils/image_psf_photometry_withNIRCam.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"data/photutils_banner.svg\" width=500 alt=\"Photutils logo\">"
+    "<img src=\"data/photutils_banner.svg\" width=500 alt=\"Photutils logo\" style=\"margin-left: 0;\">"
    ]
   },
   {
@@ -17,28 +17,15 @@
     "- Documentation: https://photutils.readthedocs.io/en/stable/\n",
     "- Issue Tracker:  https://github.com/astropy/photutils/issues\n",
     "\n",
-    "## Photutils capabilities:\n",
     "\n",
-    "- Background and background noise estimation\n",
-    "- Source Detection and Extraction\n",
-    "  - DAOFIND and IRAF's starfind\n",
-    "  - Image segmentation\n",
-    "  - local peak finder\n",
-    "- Aperture photometry\n",
-    "- PSF photometry\n",
-    "- ePSF building\n",
-    "- PSF matching\n",
-    "- Centroids\n",
-    "- Morphological properties\n",
-    "- Elliptical isophote analysis\n",
-    "\n",
-    "\n",
-    "## In this additional notebook, we will review:\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<h2 style=\"margin-top: 0\">In this notebook, we will cover:</h2>\n",
     "\n",
     "- PSF photometry extracting PSFs from an input image\n",
     "    - Use a simulated image of elliptical PSFs\n",
     "    - Use a JWST NIRCam simulated image\n",
-    "\n",
+    "</div>\n",
+    "    \n",
     "---"
    ]
   },
@@ -47,6 +34,13 @@
    "metadata": {},
    "source": [
     "# Demonstration of `photutils.psf` with an image-based PSF Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preliminaries"
    ]
   },
   {
@@ -80,19 +74,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import photutils\n",
-    "from photutils import psf\n",
-    "from astropy.modeling import models\n",
-    "\n",
-    "photutils.__version__"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -105,6 +86,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from photutils import psf\n",
+    "from astropy.modeling import models\n",
+    "\n",
     "psfmodel = ((models.Shift(-5) & models.Shift(2)) | \n",
     "            models.Rotation2D(-20) | \n",
     "            (models.Identity(1) & models.Scale(1.5)) | \n",
@@ -178,7 +162,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Now lets try doing photometry"
+    "## Now let's try doing photometry"
    ]
   },
   {
@@ -202,8 +186,9 @@
    "outputs": [],
    "source": [
     "from astropy.stats import SigmaClip\n",
-    "bkg_var = photutils.background.BiweightScaleBackgroundRMS(\n",
-    "            sigma_clip=SigmaClip(3))(im)\n",
+    "from photutils.background import BiweightScaleBackgroundRMS\n",
+    "\n",
+    "bkg_var = BiweightScaleBackgroundRMS(sigma_clip=SigmaClip(3))(im)\n",
     "bkg_var"
    ]
   },
@@ -211,7 +196,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we create a `DAOStarFinder` object and run that on the image"
+    "Then we create a `DAOStarFinder` object and run that on the image."
    ]
   },
   {
@@ -220,8 +205,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "star_finder = photutils.detection.DAOStarFinder(threshold=bkg_var/2, \n",
-    "                                                fwhm=5)\n",
+    "from photutils.detection import DAOStarFinder\n",
+    "\n",
+    "star_finder = DAOStarFinder(threshold=bkg_var/2, fwhm=5)\n",
     "found_stars = star_finder(im)\n",
     "\n",
     "plt.imshow(im)\n",
@@ -268,7 +254,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And now we try making a residual image to see how well it did"
+    "And now we try making a residual image to see how well it did."
    ]
   },
   {
@@ -290,7 +276,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Well that looks OK except that it looks ugly because our psf model that we fit was a bit small.  So lets try subtracting the *actual* model"
+    "Well that looks OK except that it looks ugly because our psf model that we fit was a bit small.  So let's try subtracting the *actual* model."
    ]
   },
   {
@@ -315,14 +301,14 @@
    "metadata": {},
    "source": [
     "---\n",
-    "# Simulated NIRCam data "
+    "# Simulated JWST/NIRCam data "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now lets try something like the above, but with simulated NIRCam data, using an oversampled PSF.  \n",
+    "Now let's try something like the above, but with simulated JWST/NIRCam data, using an oversampled PSF.  \n",
     "\n",
     "In principal this is one of two modes one might take with real JWST data.  For many cases using a provided PSF (or generated from `webbpsf`) will be sufficient.  `photutils` also has a high-level tool to build an effective PSF (ePSF) directly from the image (see https://photutils.readthedocs.io/en/latest/epsf.html)."
    ]
@@ -363,9 +349,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# this is a quick-and-easy way to re-scale an image, using the \n",
+    "# this is a quick-and-easy way to rescale an image, using the \n",
     "# astropy.visualization package\n",
     "from astropy.visualization import simple_norm\n",
+    "\n",
     "norm = simple_norm(im1, 'log', percent=99.)\n",
     "\n",
     "# or equivalent\n",
@@ -380,7 +367,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "OK, lets histogram it so we can see roughly where the threshold should be"
+    "OK, let's histogram it so we can see roughly where the threshold should be."
    ]
   },
   {
@@ -398,7 +385,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dsf = photutils.DAOStarFinder(100, 5)\n",
+    "dsf = DAOStarFinder(100, 5)\n",
     "found_stars = dsf(im1)\n",
     "found_stars['xcentroid'].name = 'x_0'\n",
     "found_stars['ycentroid'].name = 'y_0'\n",
@@ -416,7 +403,7 @@
     "plt.imshow(im1, norm=norm)\n",
     "plt.scatter(found_stars['x_0'], found_stars['y_0'], lw=0, s=3, c='k')\n",
     "plt.xlim(500, 1500)\n",
-    "plt.ylim(500, 1500)"
+    "plt.ylim(500, 1500);"
    ]
   },
   {
@@ -445,7 +432,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Lets now zoom in on the image somewhere and see how the model looks compared to the actual image scale"
+    "Let's now zoom in on the image somewhere and see how the model looks compared to the actual image scale."
    ]
   },
   {
@@ -464,7 +451,7 @@
     "xg, yg = np.mgrid[-25:25, -25:25]\n",
     "psf_norm2 = simple_norm(psfmodel(xg, yg), 'log', percent=99.)\n",
     "ax2.imshow(psfmodel(xg, yg), norm=psf_norm2)\n",
-    "ax2.set_title('PSF')"
+    "ax2.set_title('PSF');"
    ]
   },
   {
@@ -491,7 +478,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now lets inspect the residual image as a whole, and zoomed in on a few particular stars."
+    "Now let's inspect the residual image as a whole, and zoomed in on a few particular stars."
    ]
   },
   {
@@ -550,7 +537,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For this simulated data set we only have one band, so there's not much output \"science\" to show... But below you see how to get out magnitudes, "
+    "For this simulated data set we only have one band, so there's not much output \"science\" to show... But below you see how to get out magnitudes."
    ]
   },
   {
@@ -559,14 +546,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# this does not yet exist... but the plan is that it will at launch!\n",
-    "#jwst_calibrated_mags(results['flux_fit'], im1h)\n",
-    "\n",
-    "# it would do something like this:\n",
-    "\n",
     "# this zero-point is just a made-up number right now, \n",
     "# but it's something the instrument team will provide\n",
-    "inst_mag = -2.5*np.log10(results['flux_fit'])\n",
+    "inst_mag = -2.5 * np.log10(results['flux_fit'])\n",
     "zero_point = 31.2  \n",
     "results['cal_mag'] = zero_point + inst_mag\n",
     "\n",
@@ -626,20 +608,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": true,
-   "sideBar": true,
-   "skip_h1_title": false,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": false,
-   "toc_position": {},
-   "toc_section_display": true,
-   "toc_window_display": false
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,

--- a/09-Photutils/photutils_extended.ipynb
+++ b/09-Photutils/photutils_extended.ipynb
@@ -8,7 +8,7 @@
     }
    },
    "source": [
-    "<img src=\"data/photutils_banner.svg\" width=500 alt=\"Photutils logo\">"
+    "<img src=\"data/photutils_banner.svg\" width=500 alt=\"Photutils logo\" style=\"margin-left: 0;\">"
    ]
   },
   {
@@ -25,26 +25,14 @@
     "- Documentation: https://photutils.readthedocs.io/en/stable/\n",
     "- Issue Tracker:  https://github.com/astropy/photutils/issues\n",
     "\n",
-    "## Photutils capabilities:\n",
-    "\n",
-    "- Background and background noise estimation\n",
-    "- Source Detection and Extraction\n",
-    "  - DAOFIND and IRAF's starfind\n",
-    "  - Image segmentation\n",
-    "  - local peak finder\n",
-    "- Aperture photometry\n",
-    "- PSF photometry\n",
-    "- ePSF building\n",
-    "- PSF matching\n",
-    "- Centroids\n",
-    "- Morphological properties\n",
-    "- Elliptical isophote analysis\n",
-    "\n",
-    "\n",
-    "## In this additional notebook, we will review:\n",
-    "\n",
-    "- Aperture photometry (repeat of photutils overview material)\n",
-    "- Using image segmentation to generate elliptical apertures of extended sources"
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<h2 style=\"margin-top: 0\">In this extended notebook, we will cover:</h2>\n",
+    "    \n",
+    "- Aperture Photometry\n",
+    "    - Bad pixel masking\n",
+    "    - Performing aperture photometry at multiple positions using multiple apertures\n",
+    "    - Encircled flux\n",
+    "    - Aperture masks"
    ]
   },
   {
@@ -94,7 +82,7 @@
     }
    },
    "source": [
-    "We'll start by reading data and error arrays from FITS files.  These are cutouts from the HST Extreme-Deep Field (XDF) taken with WFC3/IR in the F160W filter."
+    "We'll start by reading science data and error arrays from FITS files located in the [**data/**](data) subdirectory.  The FITS files contain 2D cutout images from the [Hubble Extreme-Deep Field (XDF)](https://archive.stsci.edu/prepds/xdf/) taken with the [Wide Field Camera 3 (WFC3)](https://www.stsci.edu/hst/instrumentation/wfc3) IR channel in the F160W filter (centered at ~1.6 $\\mu m$)."
    ]
   },
   {
@@ -108,93 +96,20 @@
    "outputs": [],
    "source": [
     "from astropy.io import fits\n",
+    "from astropy.wcs import WCS\n",
+    "\n",
     "sci_fn = 'data/xdf_hst_wfc3ir_60mas_f160w_sci.fits'\n",
     "rms_fn = 'data/xdf_hst_wfc3ir_60mas_f160w_rms.fits'\n",
     "sci_hdulist = fits.open(sci_fn)\n",
     "rms_hdulist = fits.open(rms_fn)\n",
     "\n",
-    "sci_hdulist[0].header['BUNIT'] = 'electron/s'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Print some info about the data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "sci_hdulist.info()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Define the data and error arrays."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "data = sci_hdulist[0].data.astype(np.float)\n",
-    "error = rms_hdulist[0].data.astype(np.float)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Extract the data header and create a WCS object."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from astropy.wcs import WCS\n",
-    "\n",
+    "data = sci_hdulist[0].data.astype(float)\n",
+    "error = rms_hdulist[0].data.astype(float)\n",
     "hdr = sci_hdulist[0].header\n",
     "wcs = WCS(hdr)"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Display the data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from astropy.visualization import simple_norm"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -204,10 +119,12 @@
    },
    "outputs": [],
    "source": [
+    "from astropy.visualization import simple_norm\n",
+    "\n",
     "plt.figure(figsize=(8, 8))\n",
     "norm = simple_norm(data, 'sqrt', percent=99.)\n",
     "plt.imshow(data, norm=norm)\n",
-    "plt.title('XDF F160W Cutout')"
+    "plt.title('XDF F160W Cutout');"
    ]
   },
   {
@@ -218,8 +135,7 @@
     }
    },
    "source": [
-    "---\n",
-    "# Part 1:  Aperture Photometry"
+    "# Aperture Photometry"
    ]
   },
   {
@@ -245,18 +161,18 @@
    "source": [
     "import astropy.units as u\n",
     "from photutils.utils import calc_total_error\n",
-    "from photutils import CircularAperture, aperture_photometry\n",
+    "from photutils.aperture import CircularAperture, aperture_photometry\n",
     "\n",
     "positions = [(90.73, 59.43), (73.63, 139.41), (43.62, 61.63)]\n",
     "radius = 5.\n",
     "apertures = CircularAperture(positions, r=radius)\n",
     "\n",
     "eff_gain = hdr['TEXPTIME']\n",
-    "tot_error = calc_total_error(data, error, eff_gain)\n",
+    "total_error = calc_total_error(data, error, eff_gain)\n",
     "\n",
     "unit = u.electron / u.s\n",
     "\n",
-    "phot = aperture_photometry(data * unit, apertures, error=tot_error * unit)\n",
+    "phot = aperture_photometry(data << unit, apertures, error=total_error << unit)\n",
     "phot"
    ]
   },
@@ -282,7 +198,7 @@
     "y, x = 59, 91\n",
     "data2[y, x] = 100.\n",
     "\n",
-    "aperture_photometry(data2, apertures, error=tot_error)"
+    "aperture_photometry(data2, apertures, error=total_error)"
    ]
   },
   {
@@ -305,7 +221,7 @@
     "mask = np.zeros_like(data2, dtype=bool)\n",
     "mask[y, x] = True\n",
     "\n",
-    "aperture_photometry(data2, apertures, error=tot_error, mask=mask)"
+    "aperture_photometry(data2, apertures, error=total_error, mask=mask)"
    ]
   },
   {
@@ -357,7 +273,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "phot = aperture_photometry(data * unit, apertures, error=tot_error * unit)\n",
+    "phot = aperture_photometry(data << unit, apertures, error=total_error << unit)\n",
     "phot"
    ]
   },
@@ -365,7 +281,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The output table above now contains columns for the `aperture_sum` and `aperture_sum_err` for each aperture.  The column names are appended with `_N`, where N is running index of the apertures in the input `apertures` list, i.e. the first aperture is `_0`, the second is `_1`, etc."
+    "The output table above now contains multiple columns for the `aperture_sum` and `aperture_sum_err` for each aperture.  The column names are appended with `_N`, where N is running index of the apertures in the input `apertures` list, i.e., the first aperture is `_0`, the second is `_1`, etc."
    ]
   },
   {
@@ -381,22 +297,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "phot['aperture_radius_0'] = np.ones(len(phot)) * radii[0] * u.pix\n",
-    "phot['aperture_radius_1'] = np.ones(len(phot)) * radii[1] * u.pix\n",
-    "phot['aperture_radius_2'] = np.ones(len(phot)) * radii[2] * u.pix\n",
-    "phot['aperture_radius_3'] = np.ones(len(phot)) * radii[3] * u.pix\n",
-    "phot\n",
-    "\n",
-    "# # A more concise way to accomplish the same thing, useful for adding many new aperture radii to the table\n",
-    "# for i, rad in enumerate(radii):\n",
-    "#     phot['aperture_radius_{}'.format(i)] = np.ones(len(phot)) * radii[i] * u.pix"
+    "for i, rad in enumerate(radii):\n",
+    "    phot[f'aperture_radius_{i}'] = np.ones(len(phot)) * radii[i] * u.pix\n",
+    "    \n",
+    "phot"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "and put them in the table metadata:"
+    "Or we can store them in the table metadata:"
    ]
   },
   {
@@ -406,7 +317,7 @@
    "outputs": [],
    "source": [
     "for i in range(len(radii)):\n",
-    "    phot.meta['aperture_{}'.format(i)] = 'Circular aperture with r={} pix'.format(radii[i])"
+    "    phot.meta[f'aperture_{i}'] = f'Circular aperture with r={radii[i]} pix'"
    ]
   },
   {
@@ -426,94 +337,6 @@
     }
    },
    "source": [
-    "## Aperture photometry using Sky apertures"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "First, let's define the sky coordinates by converting our pixel coordinates."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "positions = [(90.73, 59.43), (73.63, 139.41), (43.62, 61.63)]\n",
-    "x, y = np.transpose(positions)  # transform coordinate pairs to a list of x and a list of y coordinates\n",
-    "coord = wcs.pixel_to_world(x, y)\n",
-    "coord"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now define a circular aperture in sky coordinates.\n",
-    "\n",
-    "For sky apertures in angular units, the aperture radius must be a `Quantity`, in either pixel or angular units."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from photutils import SkyCircularAperture\n",
-    "\n",
-    "radius = 5. * u.pix\n",
-    "sky_apers = SkyCircularAperture(coord, r=radius)\n",
-    "sky_apers.r"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "radius = 0.5 * u.arcsec\n",
-    "sky_apers = SkyCircularAperture(coord, r=radius)\n",
-    "sky_apers.r"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "When using a sky aperture in angular units, `aperture_photometry` needs the WCS transformation, which can be input via the `wcs` keyword:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "phot = aperture_photometry(data, sky_apers, wcs=wcs)\n",
-    "phot"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
     "## Encircled flux"
    ]
   },
@@ -521,7 +344,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we want to perform aperture photometry at a single position with *many* apertures.\n",
+    "Here we want to perform aperture photometry at a single position, but with *many* apertures of different radii.\n",
     "\n",
     "Instead of generating a big table, we'll simply loop over the apertures and extract the fluxes from individual tables."
    ]
@@ -535,8 +358,8 @@
     "radii = np.linspace(0.1, 20, 100)  # 100 apertures\n",
     "flux = []\n",
     "for r in radii:\n",
-    "    ap = CircularAperture(positions[1], r=r)  # single position\n",
-    "    phot = aperture_photometry(data, ap)\n",
+    "    aper = CircularAperture(positions[1], r=r)  # single position\n",
+    "    phot = aperture_photometry(data, aper)\n",
     "    flux.append(phot['aperture_sum'][0])"
    ]
   },
@@ -550,7 +373,7 @@
    },
    "outputs": [],
    "source": [
-    "plt.plot(radii, flux, '+-')\n",
+    "plt.plot(radii, flux, 'o-')\n",
     "plt.title('Encircled Flux')\n",
     "plt.xlabel('Radius (pixels)')\n",
     "plt.ylabel('Aperture Sum ($e^{-1}/s$)');"
@@ -560,14 +383,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## More about apertures:  Advanced usage"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Aperture masks"
+    "## Aperture masks"
    ]
   },
   {
@@ -672,493 +488,6 @@
     "plt.imshow(data_cutout_aper)\n",
     "plt.colorbar()"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "---\n",
-    "# Part 2:  Image Segmentation (extended version)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Image segmentation is the process where sources are identified and labeled in an image.\n",
-    "\n",
-    "The sources are detected by using a S/N threshold level and defining the minimum number of pixels required within a source.\n",
-    "\n",
-    "First, let's define a threshold image at 2$\\sigma$ (per pixel) above the background."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bkg = 0.  # background level in this image\n",
-    "nsigma = 2.\n",
-    "threshold = bkg + (nsigma * error)  # this should be background-only error"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now let's detect \"8-connected\" sources of minimum size 5 pixels where each pixel is 2$\\sigma$ above the background.\n",
-    "\n",
-    "\"8-connected\" pixels touch along their edges or corners. \"4-connected\" pixels touch along their edges. For reference, SExtractor uses \"8-connected\" pixels.\n",
-    "\n",
-    "The result is a segmentation image (`SegmentationImage` object).  The segmentation image is the isophotal footprint of each source above the threshold."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from photutils import detect_sources\n",
-    "\n",
-    "npixels = 5\n",
-    "segm = detect_sources(data, threshold, npixels)\n",
-    "\n",
-    "print('Found {0} sources'.format(segm.nlabels))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Display the segmentation image."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 10))\n",
-    "ax1.imshow(data, norm=norm)\n",
-    "lbl1 = ax1.set_title('Data')\n",
-    "ax2.imshow(segm, cmap=segm.make_cmap())\n",
-    "lbl2 = ax2.set_title('Segmentation Image')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "It is better to filter (smooth) the data prior to source detection.\n",
-    "\n",
-    "Let's use a 5x5 Gaussian kernel with a FWHM of 2 pixels."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from astropy.convolution import Gaussian2DKernel\n",
-    "from astropy.stats import gaussian_fwhm_to_sigma\n",
-    "\n",
-    "sigma = 2.0 * gaussian_fwhm_to_sigma  # FWHM = 2 pixels\n",
-    "kernel = Gaussian2DKernel(sigma, x_size=5, y_size=5)\n",
-    "kernel.normalize()\n",
-    "\n",
-    "ssegm = detect_sources(data, threshold, npixels, filter_kernel=kernel)\n",
-    "print('Found {0} sources'.format(ssegm.nlabels))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 10))\n",
-    "ax1.imshow(segm, cmap=segm.make_cmap())\n",
-    "lbl1 = ax1.set_title('Original Data Segmentation')\n",
-    "ax2.imshow(ssegm, cmap=ssegm.make_cmap())\n",
-    "lbl2 = ax2.set_title('Smoothed Data Segmentation')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Source deblending"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "Note above that some of our detected sources were blended.  We can deblend them using the `deblend_sources()` function, which uses a combination of multi-thresholding and watershed segmentation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from photutils import deblend_sources\n",
-    "\n",
-    "segm2 = deblend_sources(data, ssegm, npixels, filter_kernel=kernel,\n",
-    "                        contrast=0.001, nlevels=32)\n",
-    "\n",
-    "fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(15, 8))\n",
-    "ax1.imshow(data, norm=norm)\n",
-    "ax1.set_title('Data')\n",
-    "ax2.imshow(ssegm, cmap=ssegm.make_cmap())\n",
-    "ax2.set_title('Original Segmentation Image')\n",
-    "ax3.imshow(segm2, cmap=segm2.make_cmap())\n",
-    "ax3.set_title('Deblended Segmentation Image')\n",
-    "\n",
-    "print('Found {0} sources'.format(segm2.nlabels))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "## Measure the photometry and morphological properties of detected sources"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from photutils import source_properties\n",
-    "catalog = source_properties(data, segm2, error=error, wcs=wcs)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`catalog` is a `SourceCatalog` object.  It behaves like a list of `SourceProperties` objects, one for each source."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "catalog"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "catalog[0]  # the first source"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "catalog[0].xcentroid  # the xcentroid of the first source"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Please go [here](http://photutils.readthedocs.io/en/latest/api/photutils.segmentation.SourceProperties.html#photutils.segmentation.SourceProperties) to see the complete list of available source properties."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can create a Table of isophotal photometry and morphological properties using the ``to_table()`` method of `SourceCatalog`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "tbl = catalog.to_table()\n",
-    "tbl"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A subset of source can be specified, defined by the their labels in the segmentation image."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "labels = [1, 5, 7, 12]\n",
-    "cat2 = source_properties(data, segm, error=error, wcs=wcs, labels=labels)\n",
-    "tbl2 = cat2.to_table()\n",
-    "tbl2"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A subset of property columns can also be specified."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "columns = ['id', 'xcentroid', 'ycentroid', 'source_sum', 'area']\n",
-    "tbl3 = catalog.to_table(columns=columns)\n",
-    "tbl3"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "or a subset of sources with a subset of properties:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tbl4 = cat2.to_table(columns=columns)\n",
-    "tbl4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Additional properties (not stored in the table) can be accessed directly via the `SourceCatalog` object."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# get a single object (id=12)\n",
-    "obj = catalog[11]\n",
-    "obj.id"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "obj"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's plot the cutouts of the data and error images for this source."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, ax = plt.subplots(figsize=(12, 8), ncols=3)\n",
-    "ax[0].imshow(obj.make_cutout(segm2.data))\n",
-    "ax[0].set_title('Source id={} Segment'.format(obj.id))\n",
-    "ax[1].imshow(obj.data_cutout_ma)\n",
-    "ax[1].set_title('Source id={} Data'.format(obj.id))\n",
-    "ax[2].imshow(obj.error_cutout_ma)\n",
-    "ax[2].set_title('Source id={} Error'.format(obj.id));"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "## Define the approximate isophotal ellipses for each object"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Create elliptical apertures for each object using the measured morphological parameters."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "-"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from photutils import EllipticalAperture\n",
-    "\n",
-    "r = 3.  # approximate isophotal extent\n",
-    "apertures = []\n",
-    "for obj in catalog:\n",
-    "    position = (obj.xcentroid.value, obj.ycentroid.value)\n",
-    "    a = obj.semimajor_axis_sigma.value * r\n",
-    "    b = obj.semiminor_axis_sigma.value * r\n",
-    "    theta = obj.orientation.value\n",
-    "    apertures.append(EllipticalAperture(position, a, b, theta=theta))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now plot the elliptical apertures on the data and the segmentation image."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 10))\n",
-    "ax1.imshow(data, norm=norm)\n",
-    "ax1.set_title('Data')\n",
-    "ax2.imshow(segm2, cmap=segm2.make_cmap())\n",
-    "ax2.set_title('Segmentation Image')\n",
-    "for aperture in apertures:\n",
-    "    aperture.plot(color='white', lw=1.5, alpha=0.8, axes=ax1)\n",
-    "    aperture.plot(color='white', lw=1.5, alpha=1.0, axes=ax2)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "_Note that the segmentation image can be reused on other registered data (e.g., multiple filters) to generate a multiband catalog.  One does not need to regenerate it each time -- simply apply it to other bands and/or data._"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "The segmentation image can also be modified before measuring source photometry/properties, e.g.:\n",
-    "\n",
-    " - remove source segments (artifacts, diffraction spikes, etc.)\n",
-    " - combine segments\n",
-    " - mask regions of a segmentation image (e.g. near image borders)\n",
-    "\n",
-    "See [modifying segmentation images](https://photutils.readthedocs.io/en/stable/segmentation.html#modifying-a-segmentation-image) for further information."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "If desired, a `SExtractor` segmentation image can even be input to Photutils `source_properties()`.\n",
-    "\n",
-    "To generate a `SExtractor` segmentation image, set the following in the SExtractor config:\n",
-    "```\n",
-    "CHECKIMAGE_TYPE   SEGMENTATION\n",
-    "CHECKIMAGE_NAME   segmentation.fits\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Once `segmentation.fits` exists, one could do the following:\n",
-    "\n",
-    "`>>> from photutils import SegmentationImage`\n",
-    "\n",
-    "`>>> se_segm_data = fits.getdata('segmentation_fits')`\n",
-    "\n",
-    "`>>> se_segm = SegmentationImage(se_segm_data)`\n",
-    "\n",
-    "`>>> se_cat = source_properties(data, se_segm, error=error, wcs=wcs, labels=labels)`\n",
-    "\n",
-    "Note that `data` and `se_segm_data` must have the same shape and be registered."
-   ]
   }
  ],
  "metadata": {
@@ -1178,7 +507,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,

--- a/09-Photutils/photutils_local_backgrounds.ipynb
+++ b/09-Photutils/photutils_local_backgrounds.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"data/photutils_banner.svg\" width=500 alt=\"Photutils logo\">"
+    "<img src=\"data/photutils_banner.svg\" width=500 alt=\"Photutils logo\" style=\"margin-left: 0;\">"
    ]
   },
   {
@@ -17,26 +17,13 @@
     "- Documentation: https://photutils.readthedocs.io/en/stable/\n",
     "- Issue Tracker:  https://github.com/astropy/photutils/issues\n",
     "\n",
-    "## Photutils capabilities:\n",
     "\n",
-    "- Background and background noise estimation\n",
-    "- Source Detection and Extraction\n",
-    "  - DAOFIND and IRAF's starfind\n",
-    "  - Image segmentation\n",
-    "  - local peak finder\n",
-    "- Aperture photometry\n",
-    "- PSF photometry\n",
-    "- ePSF building\n",
-    "- PSF matching\n",
-    "- Centroids\n",
-    "- Morphological properties\n",
-    "- Elliptical isophote analysis\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<h2 style=\"margin-top: 0\">In this notebook, we will cover:</h2>\n",
     "\n",
-    "\n",
-    "## In this additional notebook, we will review:\n",
-    "\n",
-    "- Background and background noise estimation\n",
+    "- Local background estimation\n",
     "- Aperture mask objects\n",
+    "</div>\n",
     "\n",
     "---"
    ]
@@ -45,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Local Background Subtraction in Photutils"
+    "# Local Background Subtraction"
    ]
   },
   {
@@ -95,7 +82,7 @@
     }
    },
    "source": [
-    "We'll start by reading data and error arrays from FITS files.  This is a small region from the Extreme-Deep Field (XDF) taken with WFC3/IR in the F160W filter."
+    "We'll start by reading science data and error arrays from FITS files located in the [**data/**](data) subdirectory.  The FITS files contain 2D cutout images from the [Hubble Extreme-Deep Field (XDF)](https://archive.stsci.edu/prepds/xdf/) taken with the [Wide Field Camera 3 (WFC3)](https://www.stsci.edu/hst/instrumentation/wfc3) IR channel in the F160W filter (centered at ~1.6 $\\mu m$)."
    ]
   },
   {
@@ -130,14 +117,14 @@
     "from photutils.utils import calc_total_error\n",
     "\n",
     "eff_gain = hdr['TEXPTIME']\n",
-    "tot_error = calc_total_error(data, error, eff_gain)"
+    "total_error = calc_total_error(data, error, eff_gain)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The background in the XDF image has already been subtracted.  Let's add a background of 5 e-/s."
+    "The background in the XDF image has already been subtracted.  Let's add a background of 5 e-/s so we'll have something to subtract."
    ]
   },
   {
@@ -165,7 +152,7 @@
     "plt.figure(figsize=(8, 8))\n",
     "norm = simple_norm(data, 'sqrt', percent=99.5)\n",
     "plt.imshow(data, norm=norm)\n",
-    "plt.colorbar()"
+    "plt.colorbar(shrink=0.8)"
    ]
   },
   {
@@ -190,10 +177,10 @@
    "outputs": [],
    "source": [
     "# define three apertures\n",
-    "from photutils import CircularAperture\n",
+    "from photutils.aperture import CircularAperture\n",
     "\n",
     "positions = [(90.73, 59.43), (73.63, 139.41), (43.62, 61.63)]\n",
-    "radius = 5.\n",
+    "radius = 5.  # pixels\n",
     "apertures = CircularAperture(positions, r=radius)"
    ]
   },
@@ -206,7 +193,7 @@
     "# plot the apertures\n",
     "plt.figure(figsize=(8, 8))\n",
     "plt.imshow(data, norm=norm)\n",
-    "apertures.plot(color='red', lw=2)"
+    "apertures.plot(color='red', lw=2);"
    ]
   },
   {
@@ -223,10 +210,10 @@
     "# data here includes background, so the aperture sums are *not* the source fluxes\n",
     "# ideally the data array should be background subtracted before running aperture_photometry\n",
     "import astropy.units as u\n",
-    "from photutils import aperture_photometry\n",
+    "from photutils.aperture import aperture_photometry\n",
     "\n",
     "unit = u.electron / u.s\n",
-    "phot = aperture_photometry(data * unit, apertures, error=tot_error * unit)\n",
+    "phot = aperture_photometry(data << unit, apertures, error=total_error << unit)\n",
     "phot"
    ]
   },
@@ -241,9 +228,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, let's create circular and circular-annulus apertures at the same positions.\n",
+    "Let's start by creating circular-annulus apertures at the same positions.\n",
     "\n",
-    "Here we're define a r=5 pixel circular aperture and a circular annulus with inner and outer radii of 10 and 15 pixels, respectively.\n",
+    "Here we're define each circular annulus to have an inner and outer radius of 10 and 15 pixels, respectively.\n",
     "\n",
     "The circular-annulus apertures will be used for local background estimation around the sources."
    ]
@@ -254,7 +241,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from photutils import CircularAnnulus\n",
+    "from photutils.aperture import CircularAnnulus\n",
     "\n",
     "positions = [(90.73, 59.43), (73.63, 139.41), (43.62, 61.63)]\n",
     "aper = CircularAperture(positions, r=5)\n",
@@ -271,8 +258,11 @@
     "# plot the apertures\n",
     "plt.figure(figsize=(8, 8))\n",
     "plt.imshow(data, norm=norm)\n",
-    "aper.plot(color='white', lw=2)\n",
-    "bkg_aper.plot(color='orange', lw=2)"
+    "aper_patches = aper.plot(color='white', lw=2, label='Photometry aperture')\n",
+    "ann_patches = bkg_aper.plot(color='orange', lw=2, label='Background annulus', hatch='///')\n",
+    "handles = (aper_patches[0], ann_patches[0])\n",
+    "plt.legend(loc=(0.03, 0.90), facecolor='#458989', labelcolor='white',\n",
+    "              handles=handles, prop={'weight': 'bold', 'size': 11});"
    ]
   },
   {
@@ -286,7 +276,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This simple example uses the mean value in circular annulus as the background value.  We'll use the `aperture_photometry` function to calculate the pixel sum in the circular annulus, from which we can calculate the mean background value."
+    "This first example uses the mean value in circular annulus as the background value.  We'll use the `aperture_photometry` function to calculate the pixel sum in the circular annulus, from which we can calculate the mean background value."
    ]
   },
   {
@@ -368,7 +358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "One can use aperture masks to directly access the pixel values in an aperture.  This allows for advanced local background subtraction."
+    "One can use aperture masks to directly access the pixel values in an aperture.  This allows for advanced local background subtraction including, for example, sigma clipping."
    ]
   },
   {
@@ -388,13 +378,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# bkg_mask is a list of ApertureMask objects, one for each aperture position\n",
-    "bkg_mask"
+    "`bkg_mask` is a list of [ApertureMask](https://photutils.readthedocs.io/en/latest/api/photutils.aperture.ApertureMask.html#photutils.aperture.ApertureMask) objects, one for each aperture position."
    ]
   },
   {
@@ -403,17 +390,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Let's plot the first one.\n",
-    "plt.figure(figsize=(6, 6))\n",
-    "plt.imshow(bkg_mask[0])\n",
-    "plt.colorbar()"
+    "bkg_mask"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The mask values are between 0 and 1, indicating the overlap fraction of the aperture on the pixel grid.  The fractional values (between 0 and 1) in the mask above are because the default overlap method is \"exact\".  We can use other methods, e.g., \"center\", where pixels are either completely in or out of the aperture depending on whether the pixel center is in or out of the aperture."
+    "Let's plot the first aperture mask."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.imshow(bkg_mask[0])  # index 0 means first mask\n",
+    "plt.colorbar(shrink=0.8);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The mask pixel values are between 0 and 1 (inclusive), indicating the fractional overlap of the aperture with the pixel grid.  The fractional values (between 0 and 1) on the edges are because the default overlap method is `'exact'`.  We can use other methods, e.g., `'center'`, where pixels are either completely in or out of the aperture depending on whether the pixel center is in or out of the aperture.  In that case, the mask pixel values will be either 0 or 1 (no fractional values)."
    ]
   },
   {
@@ -427,23 +429,23 @@
     "plt.figure(figsize=(6, 6))\n",
     "bkg_mask = bkg_aper.to_mask(method='center')\n",
     "plt.imshow(bkg_mask[0])\n",
-    "plt.colorbar()"
+    "plt.colorbar(shrink=0.8);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The values in the above mask are either 0 or 1.  **This type of mask is strongly recommended for local background estimation.**\n",
+    "The pixel values in the above mask are either 0 or 1.  **This type of mask (i.e., method='center') is strongly recommended for local background estimation.**\n",
     "\n",
-    "One could use the \"exact\" mask, but it requires using statistical functions that can handle partial-pixel weights.  That introduces a lot of unnecessary complexity when the aperture is simply being used to estimate the local background -- whole pixels are fine, assuming you have a sufficient number of them."
+    "One could use the `'exact'` mask, but it requires using statistical functions that can handle partial-pixel weights.  That introduces a lot of unnecessary complexity when the aperture is simply being used to estimate the local background -- whole pixels are fine, assuming you have a sufficient number of them."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now use the `ApertureMask` `multiply` method to get the values of the mask multiplied to the data.  Since the mask values are 0 or 1, this is simply the data values within the annulus aperture:"
+    "We can now use the `ApertureMask` `get_values()` method to get the mask-weighted pixel values from the data as a 1D array.  Because the mask contains only 0 or 1 values, the result is simply the data pixel values located within the annulus aperture."
    ]
   },
   {
@@ -455,42 +457,10 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(6, 6))\n",
-    "bmask = bkg_mask[0]  # first aperture\n",
-    "data1 = bmask.multiply(data)\n",
-    "plt.imshow(data1, vmin=4.998, vmax=5.002)\n",
-    "plt.colorbar()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "From this 2D array, you can extract a 1D array of data values (e.g., if you don't care about their spatial positions, which is probably most cases).  You can then use your favorite statistical estimator on this data to estimate the background level."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# extract the data within the aperture\n",
-    "# data_values is a 1D ndarray\n",
-    "idx = bmask.data > 0\n",
-    "aper_data = data1[idx]\n",
-    "aper_data.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# to calculate the mask weights (e.g., needed for method='exact')\n",
-    "# for method='center' the weights will all be 1.\n",
-    "weights = bmask.data[idx]\n",
-    "weights.shape"
+    "bmask = bkg_mask[0]  # first aperture mask\n",
+    "aper_data = bmask.get_values(data)\n",
+    "plt.plot(aper_data)\n",
+    "plt.axhline(5.0, color='orange');"
    ]
   },
   {
@@ -500,7 +470,15 @@
    "outputs": [],
    "source": [
     "# distribution of data values in the annulus aperture\n",
-    "plt.hist(aper_data, bins=20);"
+    "plt.hist(aper_data, bins=20);\n",
+    "plt.axvline(5.0, color='orange');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can then use your favorite statistical estimator on this data to estimate the background level."
    ]
   },
   {
@@ -521,6 +499,7 @@
    "source": [
     "# sigma-clipped mean and median\n",
     "from astropy.stats import sigma_clipped_stats\n",
+    "\n",
     "mean_sigclip, median_sigclip, std_sigclip = sigma_clipped_stats(aper_data)\n",
     "mean_sigclip, median_sigclip"
    ]
@@ -533,6 +512,7 @@
    "source": [
     "# biweight \"mean\"\n",
     "from astropy.stats import biweight_location\n",
+    "\n",
     "biweight_location(aper_data)"
    ]
   },
@@ -540,7 +520,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These background estimates represent the background *per pixel* for the first source only.  Like the first simple local background example, be sure to calculate the total background with the circular aperture before subtracting.  The area of the 'exact' circular aperture that we used for photometry is returned by its `area()` method."
+    "These background estimates represent the background *per pixel* for the first source only.  Like the first  local background example, be sure to calculate the total background within the circular aperture before subtracting.  The area of the `'exact'` circular aperture that we used for photometry is returned by its `area()` method."
    ]
   },
   {
@@ -556,13 +536,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# now subtract the background from the first source\n",
-    "phot['aperture_sum'][0] - bkg_total"
+    "Now let's subtract the background from the first source."
    ]
   },
   {
@@ -571,8 +548,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# which is close to our first simple local background estimate (simple mean)\n",
-    "# because there were not any outliers in the background annulus\n",
+    "phot['aperture_sum'][0] - bkg_total"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Because there were not any outliers in the background annulus, the result is very close to our first local background estimate (based on a simple mean)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "phot['aperture_sum_bkgsub'][0]"
    ]
   },
@@ -593,17 +584,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, let's calculate the sigma-clipped median values in each of the background annuli."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# these are the sigma-clipped median values in each of the background annuli\n",
     "bkg_median = []\n",
     "bkg_mask = bkg_aper.to_mask(method='center')\n",
     "for mask in bkg_mask:\n",
-    "    aper_data = bmask.multiply(data)\n",
-    "    aper_data = aper_data[mask.data > 0]\n",
+    "    aper_data = bmask.get_values(data)\n",
     "    \n",
     "    # perform a sigma-clipped median\n",
     "    _, median_sigclip, _ = sigma_clipped_stats(aper_data)\n",
@@ -614,13 +610,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again, the above values are the background *per pixel*.  Let's correct for the circular aperture area, subtract the background, and add them as table columns (`annulus_median`, `aperture_bkg2`, and `aperture_sum_bksub2`).\n",
+    "\n",
+    "The simple mean columns are in the table for comparison."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# correct for aperture area, subtract the background, and add table columns\n",
-    "# The simple mean columns are in the table for comparison.\n",
     "phot['annulus_median'] = bkg_median\n",
     "phot['aperture_bkg2'] = bkg_median * aper.area\n",
     "phot['aperture_sum_bkgsub2'] = phot['aperture_sum'] - phot['aperture_bkg2']\n",
@@ -638,7 +641,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Cutouts of each source using the minimal bounding box of each aperture can be obtained using the `cutout()` method."
+    "Cutouts of each source using the minimal bounding box of each aperture can be obtained using its `cutout()` method."
    ]
   },
   {
@@ -648,7 +651,15 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(5, 5))\n",
+    "# bmask was defined above as the aperture mask of the first source\n",
     "plt.imshow(bmask.cutout(data))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `multiply()` method produces a 2D image of the aperture mask multiplied by the data cutout."
    ]
   },
   {
@@ -668,8 +679,8 @@
     "plt.imshow(bmask.cutout(data))\n",
     "\n",
     "plt.subplot(1, 3, 3)\n",
-    "plt.title('Mask * Data Cutout')\n",
-    "plt.imshow(bmask.multiply(data), vmin=4.998, vmax=5.002)"
+    "plt.title('Aperture Mask * Data Cutout')\n",
+    "plt.imshow(bmask.multiply(data), vmin=4.998, vmax=5.002);"
    ]
   },
   {
@@ -733,7 +744,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,

--- a/09-Photutils/photutils_overview.ipynb
+++ b/09-Photutils/photutils_overview.ipynb
@@ -8,7 +8,14 @@
     }
    },
    "source": [
-    "<img src=\"data/photutils_banner.svg\" width=500 alt=\"Photutils logo\">"
+    "<img src=\"data/photutils_banner.svg\" width=500 alt=\"Photutils logo\" style=\"margin-left: 0;\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Photutils is an Astropy coordinated package for detecting and performing photometry of astronomical sources."
    ]
   },
   {
@@ -29,11 +36,11 @@
     "\n",
     "- Background and background noise estimation\n",
     "- Source Detection and Extraction\n",
-    "  - DAOFIND and IRAF's starfind\n",
+    "  - Star finders, e.g., DAOFIND\n",
+    "  - Local peak finder\n",
     "  - Image segmentation\n",
-    "  - local peak finder\n",
     "- Aperture photometry\n",
-    "- PSF photometry\n",
+    "- PSF-fitting photometry\n",
     "- ePSF building\n",
     "- PSF matching\n",
     "- Centroids\n",
@@ -41,10 +48,14 @@
     "- Elliptical isophote analysis\n",
     "\n",
     "\n",
-    "## In this section, we will:\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<h2 style=\"margin-top: 0\">In this notebook, we will:</h2>\n",
     "\n",
-    "- Learn how to perform aperture photometry\n",
-    "- Learn how to use photutils' image segmentation subpackage\n",
+    "- Learn the basics to perform aperture photometry\n",
+    "- Learn the basics of the image segmentation subpackage\n",
+    "\n",
+    "This notebook builds on the previous tutorials for Astropy Units/Quantities, Coordinates, FITS, and Tables.\n",
+    "</div>\n",
     "\n",
     "---"
    ]
@@ -96,16 +107,7 @@
     }
    },
    "source": [
-    "We'll start by reading data and error arrays from FITS files.  These are cutouts from the HST Extreme-Deep Field (XDF) taken with WFC3/IR in the F160W filter."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from astropy.io import fits"
+    "We'll start by reading science data and error arrays from FITS files located in the [**data/**](data) subdirectory.  The FITS files contain 2D cutout images from the [Hubble Extreme-Deep Field (XDF)](https://archive.stsci.edu/prepds/xdf/) taken with the [Wide Field Camera 3 (WFC3)](https://www.stsci.edu/hst/instrumentation/wfc3) IR channel in the F160W filter (centered at ~1.6 $\\mu m$)."
    ]
   },
   {
@@ -118,19 +120,19 @@
    },
    "outputs": [],
    "source": [
+    "from astropy.io import fits\n",
+    "\n",
     "sci_fn = 'data/xdf_hst_wfc3ir_60mas_f160w_sci.fits'\n",
     "rms_fn = 'data/xdf_hst_wfc3ir_60mas_f160w_rms.fits'\n",
     "sci_hdulist = fits.open(sci_fn)\n",
-    "rms_hdulist = fits.open(rms_fn)\n",
-    "\n",
-    "sci_hdulist[0].header['BUNIT'] = 'electron/s'"
+    "rms_hdulist = fits.open(rms_fn)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Print some info about the data."
+    "Let's print some information about the science data."
    ]
   },
   {
@@ -148,7 +150,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Define the data and error arrays."
+    "The data array is in the **`0`** extension, has a shape of 200 x 200 pixels, and has a data type of `float32` (32 bit floating-point numbers).\n",
+    "\n",
+    "Let's extract the data and error arrays."
    ]
   },
   {
@@ -161,15 +165,15 @@
    },
    "outputs": [],
    "source": [
-    "data = sci_hdulist[0].data.astype(np.float)\n",
-    "error = rms_hdulist[0].data.astype(np.float)"
+    "data = sci_hdulist[0].data.astype(float)\n",
+    "error = rms_hdulist[0].data.astype(float)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Extract the data header and create a WCS object."
+    "`data` and `error` are now 2D [numpy](https://numpy.org) arrays, each with a shape of 200 x 200 pixels."
    ]
   },
   {
@@ -178,7 +182,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.wcs import WCS"
+    "data.shape, error.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's extract the data header and create an Astropy [World Coordinate System (WCS)](https://docs.astropy.org/en/stable/wcs/index.html) object from the FITS header WCS information."
    ]
   },
   {
@@ -191,6 +202,8 @@
    },
    "outputs": [],
    "source": [
+    "from astropy.wcs import WCS\n",
+    "\n",
     "hdr = sci_hdulist[0].header\n",
     "wcs = WCS(hdr)"
    ]
@@ -199,16 +212,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Display the data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from astropy.visualization import simple_norm"
+    "Finally, let's display the science image.  Here we use the [astropy.visualization](https://docs.astropy.org/en/stable/visualization/index.html) subpackage to apply a square-root stretch to the data."
    ]
   },
   {
@@ -221,6 +225,8 @@
    },
    "outputs": [],
    "source": [
+    "from astropy.visualization import simple_norm\n",
+    "\n",
     "plt.figure(figsize=(8, 8))\n",
     "norm = simple_norm(data, 'sqrt', percent=99.)\n",
     "plt.imshow(data, norm=norm)\n",
@@ -243,7 +249,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Photutils provides circular, elliptical, and rectangular aperture shapes (plus annulus versions of each).  These are names of the aperture classes, defined in pixel coordinates:\n",
+    "Photutils provides circular, elliptical, and rectangular aperture shapes (plus annulus versions of each).\n",
+    "\n",
+    "Further, there are two types of aperture classes, defined either with pixel or sky (celestial) coordinates.\n",
+    "\n",
+    "These are the names of the aperture classes that are defined in pixel coordinates:\n",
     "\n",
     "* `CircularAperture`\n",
     "* `CircularAnnulus`\n",
@@ -254,7 +264,7 @@
     "* `RectangularAperture`\n",
     "* `RectangularAnnulus`\n",
     "\n",
-    "Along with variants of each, defined in celestial coordinates:\n",
+    "The aperture classes defined in celestial coordinates have `Sky` prepended to their names:\n",
     "\n",
     "* `SkyCircularAperture`\n",
     "* `SkyCircularAnnulus`\n",
@@ -265,7 +275,8 @@
     "* `SkyRectangularAperture`\n",
     "* `SkyRectangularAnnulus`\n",
     "\n",
-    "These look something like this:\n",
+    "\n",
+    "The aperture shapes look like this:\n",
     "<img src='data/apertures.png' alt='Figure of aperture shapes' width=700px>"
    ]
   },
@@ -277,16 +288,16 @@
     }
    },
    "source": [
-    "## Methods for handling aperture/pixel intersection"
+    "## Methods for handling aperture/pixel overlap"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In general, the apertures will only partially overlap some of the pixels in the data.\n",
+    "The apertures will usually only partially overlap some of the pixels in the data.\n",
     "\n",
-    "There are three methods for handling the aperture overlap with the pixel grid of the data array."
+    "Photutils apertures provide three methods for handling the aperture overlap with the pixel grid of the data array."
    ]
   },
   {
@@ -300,30 +311,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "NOTE:  the `subpixels` keyword is ignored for the **'exact'** and **'center'** methods."
+    "For the default method (`method='exact'`), the exact fractional overlap of the aperture with each pixel is calculated. Each pixel is then weighted by the exact fractional overlap of the aperture.\n",
+    "\n",
+    "For `method='center'`, a pixel is considered to be entirely in or out of the aperture depending on whether its center is located within the aperture.\n",
+    "\n",
+    "For `method='subpixel'`, pixels are divided into a number of subpixels, which are in or out of the aperture based on their centers. Each pixel is then weighted by its fraction of subpixel overlaps. For this method, the number of subpixels needs to be set with the `subpixels` keyword. The `subpixels` keyword is ignored for the `'exact'` and `'center'` methods."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Perform circular-aperture photometry on some sources in the XDF"
+    "## Creating Aperture Objects"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, we define a circular aperture at a given position and radius (in pixels)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from photutils import CircularAperture"
+    "First, let's define a circular aperture at a given (x, y) pixel position and radius (in pixels)."
    ]
   },
   {
@@ -336,9 +342,18 @@
    },
    "outputs": [],
    "source": [
+    "from photutils.aperture import CircularAperture\n",
+    "\n",
     "position = (90.73, 59.43)  # (x, y) pixel position\n",
     "radius = 5.  # pixels\n",
     "aperture = CircularAperture(position, r=radius)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our `aperture` variable is now an instance of a [CircularAperture](https://photutils.readthedocs.io/en/latest/api/photutils.aperture.CircularAperture.html#photutils.aperture.CircularAperture) object."
    ]
   },
   {
@@ -351,19 +366,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(aperture)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can plot the aperture on the data using the aperture `plot()` method:"
+    "We can plot the aperture on the data using its `plot()` method, with a custom color and line width."
    ]
   },
   {
@@ -374,16 +380,25 @@
    "source": [
     "plt.figure(figsize=(8, 8))\n",
     "plt.imshow(data, norm=norm)\n",
-    "aperture.plot(color='red', lw=2)"
+    "aperture.plot(color='red', lw=2);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's perform photometry on the data using the `aperture_photometry()` function.  **The default aperture method is 'exact'.**\n",
+    "## Performing Aperture Photometry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's perform photometry on the XDF data using this circular aperture.\n",
     "\n",
-    "Also note that the input data is assumed to have zero background.  If that is not the case, please see the documentation for the `photutils.background` subpackage for tools to help subtract the background.\n",
+    "After the aperture object is created, we can  perform the photometry using the [aperture_photometry()](https://photutils.readthedocs.io/en/latest/api/photutils.aperture.aperture_photometry.html#photutils.aperture.aperture_photometry) function.  In the most basic case, we simply need to input the data array and the aperture object. The default aperture overlap method is `'exact'`.\n",
+    "\n",
+    "Note that the input data array is assumed to be background subtracted.  If that is not the case, please see the documentation for the [photutils.background](https://photutils.readthedocs.io/en/latest/background.html) subpackage for tools to help subtract the background.\n",
     "\n",
     "<div class=\"alert alert-warning alert-block\"> \n",
     "<h3 style=\"margin-top:0;\">Learn More:</h3>\n",
@@ -397,15 +412,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from photutils import aperture_photometry"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -413,6 +419,8 @@
    },
    "outputs": [],
    "source": [
+    "from photutils.aperture import aperture_photometry\n",
+    "\n",
     "phot = aperture_photometry(data, aperture)\n",
     "phot"
    ]
@@ -421,9 +429,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The output is an Astropy `QTable` (Quantity Table) with sum of data values within the aperture (using the defined pixel overlap method).\n",
+    "The output is an Astropy `QTable` (Quantity Table) with several columns.  The sum of the data values within the circular aperture is in the `aperture_sum` column.\n",
     "\n",
-    "The table also contains metadata, which is accessed by the `meta` attribute of the table.  The metadata is stored as a python (ordered) dictionary:"
+    "The table also contains metadata, which is accessed by the `meta` attribute of the table.  The metadata is stored in a python dictionary."
    ]
   },
   {
@@ -448,7 +456,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Aperture photometry using the **'center'** method gives a slightly different (and less accurate) answer:"
+    "The other aperture overlap methods are specified using the `method` keyword.  Aperture photometry using the **'center'** method gives a slightly less accurate answer."
    ]
   },
   {
@@ -469,9 +477,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now perform aperture photometry using the **'subpixel'** method with `subpixels=5`:\n",
+    "Now perform aperture photometry using the `'subpixel'` method with `subpixels=5`:\n",
     "\n",
-    "These parameters are equivalent to SExtractor aperture photometry."
+    "These parameters are equivalent to SourceExtractor aperture photometry."
    ]
   },
   {
@@ -518,26 +526,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The error array in our XDF FITS file represents only the background error.  If we want to include the Poisson error of the source we need to calculate the **total** error (in the same units as the data):\n",
+    "The error keyword expects the **total** error array (i.e., all sources of error).  \n",
+    "\n",
+    "However, the error array in our XDF FITS file represents only the background error.  If we want to input the total error we need to also include the Poisson error of the source:\n",
+    "\n",
     "\n",
     "$\\sigma_{\\mathrm{tot}} = \\sqrt{\\sigma_{\\mathrm{b}}^2 +\n",
     "                  \\frac{I}{g}}$\n",
     "                  \n",
-    "where $\\sigma_{\\mathrm{b}}$ is the background-only error,\n",
+    "where $\\sigma_{\\mathrm{tot}}$ is the total error (in the same units as the data), $\\sigma_{\\mathrm{b}}$ is the background-only error,\n",
     "$I$ are the data values, and $g$ is the \"effective gain\".\n",
     "\n",
-    "The \"effective gain\" is the value (or an array if it's variable across an image) needed to convert the data image to count units (e.g. electrons or photons), where Poisson statistics apply.\n",
+    "The \"effective gain\" is the value (or an array if it's variable across an image) needed to convert the data image to count units (e.g., electrons or photons), where Poisson statistics apply.\n",
     "\n",
-    "Photutils provides a `calc_total_error()` function to perform this calculation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from photutils.utils import calc_total_error"
+    "Photutils provides a [calc_total_error()](https://photutils.readthedocs.io/en/stable/api/photutils.utils.calc_total_error.html) function to perform the calculation of combining background-only error with the source Poisson error."
    ]
   },
   {
@@ -547,13 +549,14 @@
    "outputs": [],
    "source": [
     "# this time include the Poisson error of the source\n",
+    "from photutils.utils import calc_total_error\n",
     "\n",
     "# our data array is in units of e-/s\n",
     "# so the \"effective gain\" should be the exposure time\n",
     "eff_gain = hdr['TEXPTIME']\n",
-    "tot_error = calc_total_error(data, error, eff_gain)\n",
+    "total_error = calc_total_error(data, error, eff_gain)\n",
     "\n",
-    "phot = aperture_photometry(data, aperture, error=tot_error)\n",
+    "phot = aperture_photometry(data, aperture, error=total_error)\n",
     "phot"
    ]
   },
@@ -561,7 +564,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The total error increased only slightly because this is a small faint source."
+    "The aperture photometry error increased only slightly because this is a small faint source."
    ]
   },
   {
@@ -572,20 +575,30 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`Quantity` inputs for the `data` and `error` arrays are also allowed.  Note that the unit must be the same for the `data` and `error` inputs."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# input the data units\n",
-    "import astropy.units as u"
+    "import astropy.units as u\n",
+    "\n",
+    "unit = u.electron / u.s  # unit for the data and error arrays\n",
+    "phot = aperture_photometry(data << unit, aperture, error=total_error << unit)\n",
+    "phot"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`Quantity` inputs for data and error are also allowed.  Note that the unit must be the same for the `data` and `error` inputs."
+    "The table columns now contain `Quantity` arrays."
    ]
   },
   {
@@ -594,9 +607,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "unit = u.electron / u.s  # unit for the data and error arrays\n",
-    "phot = aperture_photometry(data * unit, aperture, error=tot_error * unit)\n",
-    "phot"
+    "phot['aperture_sum']"
    ]
   },
   {
@@ -607,7 +618,7 @@
     }
    },
    "source": [
-    "## Performing aperture photometry at multiple positions"
+    "## Performing aperture photometry for multiple sources"
    ]
   },
   {
@@ -628,15 +639,26 @@
    "outputs": [],
    "source": [
     "positions = [(90.73, 59.43), (73.63, 139.41), (43.62, 61.63)]\n",
-    "radius = 5.\n",
+    "radius = 5.  # pixels\n",
     "apertures = CircularAperture(positions, r=radius)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "apertures"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An aperture object with multiple positions can be indexed or sliced to get a subset of apertures:"
+    "Note that an aperture object with multiple positions can be indexed or sliced to get a subset of apertures:"
    ]
   },
   {
@@ -672,14 +694,14 @@
    "source": [
     "plt.figure(figsize=(8, 8))\n",
     "plt.imshow(data, norm=norm)\n",
-    "apertures.plot(color='red', lw=2)"
+    "apertures.plot(color='red', lw=2);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's perform aperture photometry."
+    "Now let's perform aperture photometry for these three sources."
    ]
   },
   {
@@ -692,7 +714,7 @@
    },
    "outputs": [],
    "source": [
-    "phot = aperture_photometry(data * unit, apertures, error=tot_error * unit)\n",
+    "phot = aperture_photometry(data << unit, apertures, error=total_error << unit)\n",
     "phot"
    ]
   },
@@ -700,7 +722,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each source is a row in the table and is given a unique **id** (the first column)."
+    "Each source is a row in the table and is given a unique **`id`** number (the first column)."
    ]
   },
   {
@@ -718,7 +740,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can add columns to the photometry table.  Let's calculate the signal-to-noise (SNR) ratio of our sources and add it as a new column to the table."
+    "Let's calculate the signal-to-noise (SNR) ratio of our sources and add it as a new column to the table."
    ]
   },
   {
@@ -733,7 +755,6 @@
    "outputs": [],
    "source": [
     "snr = phot['aperture_sum'] / phot['aperture_sum_err']  # units will cancel\n",
-    "\n",
     "phot['snr'] = snr\n",
     "phot"
    ]
@@ -742,7 +763,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now calculate the F160W AB magnitude and add it to the table."
+    "As mentioned above, this dataset was taken with the HST WFC3/IR F160W filter.  Using the [F160W zero point](https://www.stsci.edu/hst/instrumentation/wfc3/data-analysis/photometric-calibration/ir-photometric-calibration), let's calculate the F160W AB magnitude and it as a new column in the table."
    ]
   },
   {
@@ -755,13 +776,13 @@
    },
    "outputs": [],
    "source": [
-    "f160w_zpt = 25.9463  # HST/WFC3 F160W zero point\n",
+    "f160w_zpt = 25.9463  # HST/WFC3 F160W ABmag zero point for flux in e-/s\n",
     "\n",
-    "# NOTE that the log10() function can be applied only to dimensionless quantities\n",
-    "# so we use the value() method to get the number value of the aperture sum\n",
+    "# NOTE that the log10() function can be applied only to dimensionless quantities,\n",
+    "# so we use the value attribute for Quantity objects to remove the units of the aperture sum\n",
     "abmag = -2.5 * np.log10(phot['aperture_sum'].value) + f160w_zpt\n",
     "\n",
-    "phot['abmag'] = abmag\n",
+    "phot['f160w_abmag'] = abmag\n",
     "phot"
    ]
   },
@@ -769,7 +790,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, using the WCS defined above, calculate the sky coordinates for these objects and add it to the table."
+    "Using the `WCS` transform defined when we loaded the data, we can also calculate the sky coordinates for these objects and add it to the table."
    ]
   },
   {
@@ -784,10 +805,10 @@
    "source": [
     "# convert pixel positions to sky coordinates\n",
     "x, y = np.transpose(positions)\n",
-    "coord = wcs.pixel_to_world(x, y)\n",
+    "sky_coord = wcs.pixel_to_world(x, y)  # a SkyCoord object\n",
     "\n",
     "# we can add the astropy SkyCoord object directly to the table\n",
-    "phot['sky_coord'] = coord\n",
+    "phot['sky_coord'] = sky_coord\n",
     "phot"
    ]
   },
@@ -795,29 +816,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also add separate RA and Dec columns, if preferred."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "phot['ra_icrs'] = coord.icrs.ra\n",
-    "phot['dec_icrs'] = coord.icrs.dec\n",
-    "phot"
+    "## Saving a photometry table"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we write the table to an ASCII file using the ECSV format, we can read it back in preserving all of the units, metadata, and SkyCoord objects."
+    "If we write the table to an ASCII file using the ECSV format, we can read it back in later preserving all of the table metadata and `Quantity` and `SkyCoord` objects."
    ]
   },
   {
@@ -826,7 +832,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "phot.write('my_photometry.txt', format='ascii.ecsv')"
+    "aper_filename = 'f160w_aperture_photometry.ecsv'\n",
+    "phot.write(aper_filename)"
    ]
   },
   {
@@ -835,15 +842,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# view the table on disk\n",
-    "!cat my_photometry.txt"
+    "# view the table file on disk\n",
+    "!cat f160w_aperture_photometry.ecsv"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now read the table in ECSV format."
+    "Now let's read the table into a new variable."
    ]
   },
   {
@@ -852,16 +859,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.table import QTable"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tbl = QTable.read('my_photometry.txt', format='ascii.ecsv')\n",
+    "from astropy.table import QTable\n",
+    "\n",
+    "tbl = QTable.read(aper_filename)\n",
     "tbl"
    ]
   },
@@ -871,6 +871,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# table metadata was preserved\n",
     "tbl.meta"
    ]
   },
@@ -907,6 +908,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Aperture photometry can also be performed using `SkyCoord` positions.\n",
+    "\n",
     "First, let's define the sky coordinates by converting our pixel coordinates."
    ]
   },
@@ -926,18 +929,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now define circular apertures in sky coordinates.\n",
+    "Now let's define circular apertures centered at these sky coordinates.\n",
     "\n",
-    "For sky apertures, the aperture radius must be a `Quantity`, in either pixel or angular units."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from photutils import SkyCircularAperture"
+    "For sky apertures, the aperture radius must be a `Quantity`, either in pixel or angular units."
    ]
   },
   {
@@ -950,7 +944,9 @@
    },
    "outputs": [],
    "source": [
-    "radius = 5. * u.pix\n",
+    "from photutils.aperture import SkyCircularAperture\n",
+    "\n",
+    "radius = 5. * u.pix  # pixel units\n",
     "sky_apers = SkyCircularAperture(coord, r=radius)\n",
     "sky_apers.r"
    ]
@@ -961,7 +957,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "radius = 0.5 * u.arcsec\n",
+    "radius = 0.5 * u.arcsec  # angular units\n",
     "sky_apers = SkyCircularAperture(coord, r=radius)\n",
     "sky_apers.r"
    ]
@@ -970,7 +966,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When using a sky aperture in angular units, `aperture_photometry` needs the WCS transformation, which can be input via the `wcs` keyword:"
+    "When performing photometry using a sky aperture, `aperture_photometry` needs the WCS transformation, which is input via the `wcs` keyword."
    ]
   },
   {
@@ -998,8 +994,9 @@
     "Aperture Photometry in the [Extended notebook](photutils_extended.ipynb):\n",
     "\n",
     "- Bad pixel masking\n",
+    "- Performing aperture photometry at multiple positions using multiple apertures\n",
     "- Encircled flux\n",
-    "- Aperture photometry at multiple positions using multiple apertures\n",
+    "- Aperture masks\n",
     "\n",
     "</div>"
    ]
@@ -1022,9 +1019,8 @@
    "source": [
     "Image segmentation is the process where sources are identified and labeled in an image.\n",
     "\n",
-    "The sources are detected by using a S/N threshold level — either a per-pixel threshold image or a single value for the whole image — and defining the minimum number of pixels required within a source.\n",
-    "\n",
-    "First, let's define a threshold image at 2$\\sigma$ (per pixel) above the background."
+    "The sources are detected by using a signal-to-noise threshold level.  This can be specified either as a per-pixel threshold image or a single value for the whole image.\n",
+    "First, let's define a threshold image at 2$\\sigma$ (per pixel) above the background.  Note that the `error` array below should represent the **background-only** error because the S/N threshold is defined relative to the background level."
    ]
   },
   {
@@ -1035,18 +1031,57 @@
    "source": [
     "bkg = 0.  # background level in this image\n",
     "nsigma = 2.\n",
-    "threshold = bkg + (nsigma * error)  # threshold image, this should be background-only error"
+    "threshold = bkg + (nsigma * error)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's detect \"8-connected\" sources of minimum size 5 pixels where each pixel is 2$\\sigma$ above the background.\n",
+    "The minimum size of detected sources is specified as a minimum number of connected pixels.\n",
     "\n",
     "\"8-connected\" pixels touch along their edges or corners. \"4-connected\" pixels touch along their edges. For reference, SExtractor uses \"8-connected\" pixels.\n",
     "\n",
-    "The result is a segmentation image (`SegmentationImage` object).  The segmentation image is the isophotal footprint of each source above the threshold: an array in which each object is labeled with an integer. As a simple example, a segmentation map containing two distinct sources might look like this:\n",
+    "```\n",
+    "8-connected      4-connected\n",
+    "(default) \n",
+    "\n",
+    "1 1 1              0 1 0\n",
+    "1 x 1              1 x 1\n",
+    "1 1 1              0 1 0\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's detect sources with a minimum size of 5 pixels where each pixel in the source is 2$\\sigma$ above the background.  For this we use the [detect_sources()](https://photutils.readthedocs.io/en/stable/api/photutils.segmentation.detect_sources.html) function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from photutils.segmentation import detect_sources\n",
+    "\n",
+    "npixels = 5\n",
+    "segm = detect_sources(data, threshold, npixels)\n",
+    "\n",
+    "print('Found {0} sources'.format(segm.nlabels))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The result is a segmentation image ([SegmentationImage](https://photutils.readthedocs.io/en/stable/api/photutils.segmentation.SegmentationImage.html#photutils.segmentation.SegmentationImage) object).  The segmentation image is an array with the same size as the science image in which each detected source is labeled with a unique integer value (>= 1).  Background pixels have a value of 0.  As a simple example, a segmentation map containing two distinct sources (labeled 1 and 2) might look like this:\n",
     "\n",
     "```\n",
     "0 0 0 0 0 0 0 0 0 0\n",
@@ -1059,39 +1094,14 @@
     "0 1 0 0 0 0 2 0 0 0\n",
     "0 0 0 0 0 0 0 0 0 0\n",
     "```\n",
-    "where all of the pixels labeled `1` belong to the first source, all those labeled `2` belong to the second, and all `0` pixels are designated to be background."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from photutils import detect_sources"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "npixels = 5\n",
-    "segm = detect_sources(data, threshold, npixels)\n",
-    "\n",
-    "print('Found {0} sources'.format(segm.nlabels))"
+    "where all of the pixels labeled `1` belong to the first source, all those labeled `2` belong to the second, and all those labeled `0` are background pixels."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Display the segmentation image."
+    "Let's display the segmentation image."
    ]
   },
   {
@@ -1103,7 +1113,7 @@
     "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 10))\n",
     "ax1.imshow(data, norm=norm)\n",
     "lbl1 = ax1.set_title('Data')\n",
-    "ax2.imshow(segm, cmap=segm.make_cmap())\n",
+    "ax2.imshow(segm, cmap=segm.make_cmap(seed=123))\n",
     "lbl2 = ax2.set_title('Segmentation Image')"
    ]
   },
@@ -1115,9 +1125,9 @@
     }
    },
    "source": [
-    "It is better to filter (smooth) the data prior to source detection.\n",
+    "It is usually better to smooth the data prior to source detection.\n",
     "\n",
-    "Let's use a 5x5 Gaussian kernel with a FWHM of 2 pixels."
+    "Let's create a 5x5 pixel Gaussian kernel with a FWHM of 2 pixels and input that kernel into the `detect_sources` function."
    ]
   },
   {
@@ -1127,21 +1137,14 @@
    "outputs": [],
    "source": [
     "from astropy.convolution import Gaussian2DKernel\n",
-    "from astropy.stats import gaussian_fwhm_to_sigma"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "from astropy.stats import gaussian_fwhm_to_sigma\n",
+    "\n",
     "sigma = 2.0 * gaussian_fwhm_to_sigma  # FWHM = 2 pixels\n",
     "kernel = Gaussian2DKernel(sigma, x_size=5, y_size=5)\n",
     "kernel.normalize()\n",
     "\n",
-    "ssegm = detect_sources(data, threshold, npixels, filter_kernel=kernel)\n",
-    "print('Found {0} sources'.format(ssegm.nlabels))"
+    "segm2 = detect_sources(data, threshold, npixels, filter_kernel=kernel)\n",
+    "print('Found {0} sources'.format(segm2.nlabels))"
    ]
   },
   {
@@ -1150,18 +1153,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 10))\n",
-    "ax1.imshow(segm, cmap=segm.make_cmap())\n",
-    "lbl1 = ax1.set_title('Original Data Segmentation')\n",
-    "ax2.imshow(ssegm, cmap=ssegm.make_cmap())\n",
-    "lbl2 = ax2.set_title('Smoothed Data Segmentation')"
+    "fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(12, 10))\n",
+    "ax1.imshow(data, norm=norm)\n",
+    "lbl1 = ax1.set_title('Data')\n",
+    "ax2.imshow(segm, cmap=segm.make_cmap(seed=123))\n",
+    "lbl2 = ax2.set_title('Segmentation Image')\n",
+    "ax3.imshow(segm2, cmap=segm2.make_cmap(seed=123))\n",
+    "lbl3 = ax3.set_title('Smoothed Data Segmentation')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Source deblending"
+    "## Source deblending"
    ]
   },
   {
@@ -1172,9 +1177,10 @@
     }
    },
    "source": [
-    "Note above that some of our detected sources were blended.  We can deblend them using the `deblend_sources()` function, which uses a combination of multi-thresholding and watershed segmentation.\n",
+    "Comparing the data array with the segmentation image, we see that several detected sources were blended together.  We can deblend them using the [deblend_sources()](https://photutils.readthedocs.io/en/stable/api/photutils.segmentation.deblend_sources.html#photutils.segmentation.deblend_sources) function, which uses a combination of multi-thresholding and watershed segmentation.\n",
     "\n",
-    "How the sources are deblended can be controlled with the two keywords `nlevels` and `contrast`:\n",
+    "The amount of deblending can be controlled with the two deblend_sources() keywords `nlevels` and `contrast`: \n",
+    "\n",
     "- `nlevels` is the number of multi-thresholding levels to use\n",
     "- `contrast` is the fraction of the total source flux that a local peak must have to be considered as a separate object"
    ]
@@ -1185,24 +1191,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from photutils import deblend_sources"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "segm2 = deblend_sources(data, ssegm, npixels, filter_kernel=kernel,\n",
+    "from photutils.segmentation import deblend_sources\n",
+    "\n",
+    "segm3 = deblend_sources(data, segm2, npixels, filter_kernel=kernel,\n",
     "                        contrast=0.001, nlevels=32)\n",
     "\n",
     "fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(15, 8))\n",
     "ax1.imshow(data, norm=norm)\n",
     "ax1.set_title('Data')\n",
-    "ax2.imshow(ssegm, cmap=ssegm.make_cmap())\n",
+    "ax2.imshow(segm2, cmap=segm2.make_cmap(seed=123))\n",
     "ax2.set_title('Original Segmentation Image')\n",
-    "ax3.imshow(segm2, cmap=segm2.make_cmap())\n",
+    "ax3.imshow(segm3, cmap=segm3.make_cmap(seed=123))\n",
     "ax3.set_title('Deblended Segmentation Image')\n",
     "\n",
     "print('Found {0} sources'.format(segm2.nlabels))"
@@ -1220,12 +1219,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "from photutils import source_properties"
+    "The [SourceCatalog](https://photutils.readthedocs.io/en/stable/api/photutils.segmentation.SourceCatalog.html#photutils.segmentation.SourceCatalog) class is used for measuring the centroids, photometry, and morphological properties of sources defined in a segmentation image. We create a `SourceCatalog` object by inputing the data array and the segmentation image, along with optional keywords such as the total error array and WCS transform."
    ]
   },
   {
@@ -1234,16 +1231,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "catalog = source_properties(data, segm2, error=error, wcs=wcs)"
+    "from photutils.segmentation import SourceCatalog\n",
+    "\n",
+    "catalog = SourceCatalog(data << unit, segm3, error=total_error << unit, wcs=wcs)\n",
+    "catalog"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`catalog` is a `SourceCatalog` object.  It behaves like a list of `SourceProperties` objects, one for each source.\n",
+    "Our `catalog` variable is a `SourceCatalog` object. The properties of each source can be accessed using `SourceCatalog` attributes or they can be output to an Astropy `QTable` using the `to_table()` method.\n",
     "\n",
-    "The `to_table` method converts a subset of the `SourceCatalog` object properties (e.g., the scalar properties) to a `QTable`. We will do this so we can write the table to disk for future use, but going forward in this example we will use the `SourceCatalog` object for analysis of the detected objects."
+    "Let's start by creating a Table of isophotal photometry and morphological properties using the `to_table()` method of `SourceCatalog`.  By default, only a subset of source properties are in the output table. Additional columns can be specified using the `columns` keyword.\n",
+    "\n",
+    "Please see the [SourceCatalog documentation](https://photutils.readthedocs.io/en/latest/api/photutils.segmentation.SourceCatalog.html#photutils.segmentation.SourceCatalog) for a complete list of the available source properties."
    ]
   },
   {
@@ -1252,9 +1254,49 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "catalog_to_tab = catalog.to_table() # convert to QTable\n",
-    "catalog_to_tab.remove_columns(['sky_centroid', 'sky_centroid_icrs'])  # remove skycoord columns (will be useful later on)\n",
-    "catalog_to_tab.write('my_detected_sources.ecsv')  # write to file"
+    "catalog_tbl = catalog.to_table()\n",
+    "catalog_tbl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each row in the table represents a source. The columns contain the calculated source properties.  The `label` column contains a unique label number for each source corresponding to the label values in the `SegmentationImage`.\n",
+    "\n",
+    "Let's save this table to an ESCV file so it can be used later in the exercises.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalog_tbl.write('xdf_f160w_catalog.ecsv', overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's also save the `SegmentationImage` to a FITS file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fits.writeto('xdf_f160w_segm.fits', segm3.data, overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also access the source properties as attributes of the `SourceCatalog` object."
    ]
   },
   {
@@ -1272,7 +1314,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "catalog[0]  # the first source"
+    "catalog.xcentroid"
    ]
   },
   {
@@ -1281,21 +1323,80 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "catalog[0].xcentroid  # the xcentroid of the first source"
+    "catalog.eccentricity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# isophotal flux\n",
+    "catalog.segment_flux"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Please go [here](http://photutils.readthedocs.io/en/latest/api/photutils.segmentation.SourceProperties.html#photutils.segmentation.SourceProperties) to see the complete list of available source properties."
+    "For example, let's plot the elliptical Kron apertures for each source."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(8, 8))\n",
+    "plt.imshow(data, norm=norm)\n",
+    "for obj in catalog:\n",
+    "    obj.kron_aperture.plot(color='red', lw=2)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can create a Table of isophotal photometry and morphological properties using the ``to_table()`` method of `SourceCatalog`:"
+    "The `SourceCatalog` object can also be indexed or sliced to select a subset of sources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "objs = catalog[0:5]  # the first 5 sources\n",
+    "objs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Subsets can also be created using a label number or list of labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "labels = [1, 2, 5, 7, 21]\n",
+    "objs = catalog.get_labels(labels)\n",
+    "objs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "objs.xcentroid"
    ]
   },
   {
@@ -1306,15 +1407,8 @@
    },
    "outputs": [],
    "source": [
-    "tbl = catalog.to_table()\n",
-    "tbl"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Additional properties (not stored in the table) can be accessed directly via the `SourceCatalog` object."
+    "objs_tbl = objs.to_table()\n",
+    "objs_tbl"
    ]
   },
   {
@@ -1323,25 +1417,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# get a single object (id=12)\n",
-    "obj = catalog[11]\n",
-    "obj.id"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "# get a single object (label=12)\n",
+    "obj = catalog.get_label(12)\n",
     "obj"
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obj.label"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's plot the cutouts of the data and error images for this source. `make_cutout` will generate a cutout of the source using the minimal bounding box of the segment."
+    "Let's plot the cutouts of the segmentation image, data, and error images for this source. These are all available as `SourceCatalog` attributes."
    ]
   },
   {
@@ -1351,12 +1445,12 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 8), ncols=3)\n",
-    "ax[0].imshow(obj.make_cutout(segm2.data))\n",
-    "ax[0].set_title('Source id={} Segment'.format(obj.id))\n",
-    "ax[1].imshow(obj.data_cutout_ma)\n",
-    "ax[1].set_title('Source id={} Data'.format(obj.id))\n",
-    "ax[2].imshow(obj.error_cutout_ma)\n",
-    "ax[2].set_title('Source id={} Error'.format(obj.id));"
+    "ax[0].imshow(obj.segment)\n",
+    "ax[0].set_title('Source label={} Segment'.format(obj.label))\n",
+    "ax[1].imshow(obj.data_ma)\n",
+    "ax[1].set_title('Source label={} Data'.format(obj.label))\n",
+    "ax[2].imshow(obj.error_ma)\n",
+    "ax[2].set_title('Source label={} Error'.format(obj.label));"
    ]
   },
   {
@@ -1370,9 +1464,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`data/xdf_hst_wfc3ir_60mas_f105w_sci.fits` is an F105W image of the same field used for the preceding examples. These images are aligned, so source positions detected in the F160W image should correspond to the same source if they are visible in the F105W image. \n",
+    "The [**data/**](data) subdirectory also contains a WFC3/IR F105W image of the same field used for the preceding examples. The F105W and F160W images are pixel aligned, so sources in the F105W image are located at the same detected positions as the F160W image (if they are visible in the F105W image). \n",
     "\n",
-    "In the F105W image, find the countrate in a 5-pixel aperture radius of the 3 brightest sources detected in the F160W image (hint: read in the table of detected sources that was written to disk in the previous example)"
+    "In the F105W image, find the count rate in a circular aperture with a 5-pixel radius of the 3 brightest sources in isophotal flux (i.e., the `segment_flux` column) detected in the F160W image.\n",
+    "\n",
+    "Hint: we previously saved the F160W catalog to an ECSV file called `xdf_f160w_catalog.ecsv`"
    ]
   },
   {
@@ -1388,17 +1484,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-warning alert-block\"> \n",
-    "<h3 style=\"margin-top:0;\">Learn More:</h3>\n",
-    "    \n",
-    "Image Segmentation in the [Extended notebook](photutils_extended.ipynb):\n",
+    "## Exercise 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calculate the $Y_{105} - H_{160}$ (F105W $-$ F160W) isophotal colors for all sources detected in the F160W image.\n",
     "\n",
-    "- Define a subset of source labels\n",
-    "- Define a subset of source properties\n",
-    "- Additional sources properties, such a cutout images\n",
-    "- Define the approximate isophotal ellipses for each source\n",
+    "The WFC3/IR F105W and F160W AB magnitude zero points are 26.2687 and 25.9463, respectively.\n",
     "\n",
-    "</div>"
+    "Hints: \n",
+    "\n",
+    "* The isophotal fluxes are found in the `segment_flux` column.\n",
+    "\n",
+    "* Because the images are pixel aligned, the F160W segmentation image can be directly applied to the F105W image.\n",
+    "\n",
+    "* We previously saved the F160W segmentation image in a file called `xdf_f160w_segm.fits`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# answer here "
    ]
   },
   {
@@ -1434,7 +1546,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,

--- a/09-Photutils/photutils_overview_solutions.ipynb
+++ b/09-Photutils/photutils_overview_solutions.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Photutils Overview"
+    "<img src=\"data/photutils_banner.svg\" width=500 alt=\"Photutils logo\" style=\"margin-left: 0;\">"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exercise solutions"
+    "# Photutils Overview Exercise Solutions"
    ]
   },
   {
@@ -25,9 +25,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`data/xdf_hst_wfc3ir_60mas_f105w_sci.fits` is an F105W image of the same field used for the preceding examples. These images are aligned, so source positions detected in the F160W image should correspond to the same source if they are visible in the F105W image. \n",
+    "The [**data/**](data) subdirectory also contains a WFC3/IR F105W image of the same field used for the preceding examples. The F105W and F160W images are pixel aligned, so sources in the F105W image are located at the same detected positions as the F160W image (if they are visible in the F105W image). \n",
     "\n",
-    "In the F105W image, find the countrate in a 5-pixel aperture radius of the 3 brightest sources detected in the F160W image (hint: read in the table of detected sources that was written to disk in the previous example)"
+    "In the F105W image, find the count rate in a circular aperture with a 5-pixel radius of the 3 brightest sources in isophotal flux (i.e., the `segment_flux` column) detected in the F160W image.\n",
+    "\n",
+    "Hint: we previously saved the F160W catalog to an ECSV file called `xdf_f160w_catalog.ecsv`"
    ]
   },
   {
@@ -37,8 +39,21 @@
    "outputs": [],
    "source": [
     "from astropy.io import fits\n",
-    "from astropy.table import Table\n",
-    "from photutils import CircularAperture, aperture_photometry"
+    "from astropy.table import QTable\n",
+    "import astropy.units as u\n",
+    "from photutils.aperture import CircularAperture, aperture_photometry\n",
+    "from photutils.segmentation import SegmentationImage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# read in the F105W science data \n",
+    "f105w_data = fits.getdata('data/xdf_hst_wfc3ir_60mas_f105w_sci.fits')\n",
+    "f105w_data *= (u.electron / u.s)"
    ]
   },
   {
@@ -49,32 +64,21 @@
    "source": [
     "import os\n",
     "\n",
-    "sources_filename = 'my_detected_sources.ecsv'\n",
+    "# these files were saved in the photutils_overview.ipynb notebook\n",
+    "f160w_catalog_filename = 'xdf_f160w_catalog.ecsv'\n",
+    "f160w_segm_filename = 'xdf_f160w_segm.fits'\n",
     "\n",
     "# This check is needed for continuous integration (CI) on GitHub.\n",
-    "has_sources_file = os.path.exists(sources_filename)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# read in the data \n",
-    "with fits.open('data/xdf_hst_wfc3ir_60mas_f105w_sci.fits') as f105w_sci_hdulist:\n",
-    "    f105w_sci_data = f105w_sci_hdulist[0].data.copy()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "has_files = (os.path.exists(f160w_catalog_filename) &\n",
+    "             os.path.exists(f160w_segm_filename))\n",
+    "\n",
     "# read in the table of sources detected in the F160W image\n",
-    "if has_sources_file:\n",
-    "    detected_sources = Table.read(sources_filename)"
+    "# and the F160W segmentation image\n",
+    "if has_files:\n",
+    "    f160w_tbl = QTable.read(f160w_catalog_filename)\n",
+    "    \n",
+    "    f160w_segm_data = fits.getdata(f160w_segm_filename)\n",
+    "    f160w_segm = SegmentationImage(f160w_segm_data)"
    ]
   },
   {
@@ -83,10 +87,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sort table by source_sum column and select the 3 brightest\n",
-    "if has_sources_file:\n",
-    "    detected_sources.sort('source_sum', reverse=True)\n",
-    "    three_brightest = detected_sources[0:3]"
+    "if has_files:\n",
+    "    # sort table by isophotal flux (the segment_flux column) and select the 3 brightest\n",
+    "    idx = np.argsort(f160w_tbl['segment_flux'])[::-1][:3]\n",
+    "    brightest = f160w_tbl[idx]\n",
+    "    print(brightest)"
    ]
   },
   {
@@ -95,28 +100,36 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if has_sources_file:\n",
-    "    # pull out x, y coordinates from table\n",
-    "    x = three_brightest['xcentroid']\n",
-    "    y = three_brightest['ycentroid']\n",
+    "if has_files:\n",
+    "    # use the (x, y) coordinates from the F160W table\n",
+    "    xypos = np.transpose((brightest['xcentroid'], brightest['ycentroid']))\n",
+    "    aperture = CircularAperture(xypos, r=5)\n",
+    "    f105w_phot = aperture_photometry(f105w_data, aperture)\n",
+    "    print(f105w_phot)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercise 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calculate the $Y_{105} - H_{160}$ (F105W $-$ F160W) isophotal colors for all sources detected in the F160W image.\n",
     "\n",
-    "    # make list of tuples of coordinate pairs\n",
-    "    positions = list(zip(x, y))\n",
-    "    print(positions)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if has_sources_file:\n",
-    "    # construct 5-pixel radius circular aperture object\n",
-    "    aperture = CircularAperture(positions, r=5)\n",
+    "The WFC3/IR F105W and F160W AB magnitude zero points are 26.2687 and 25.9463, respectively.\n",
     "\n",
-    "    # run aperture photometry\n",
-    "    phot = aperture_photometry(f105w_sci_data, aperture)"
+    "Hints: \n",
+    "\n",
+    "* The isophotal fluxes are found in the `segment_flux` column.\n",
+    "\n",
+    "* Because the images are pixel aligned, the F160W segmentation image can be directly applied to the F105W image.\n",
+    "\n",
+    "* We previously saved the F160W segmentation image in a file called `xdf_f160w_segm.fits`."
    ]
   },
   {
@@ -125,9 +138,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# inspect photometry table\n",
-    "if has_sources_file:\n",
-    "    phot"
+    "from photutils.segmentation import SourceCatalog\n",
+    "\n",
+    "if has_files:\n",
+    "    f105w_cat = SourceCatalog(f105w_data, f160w_segm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if has_files:\n",
+    "    f105w_abmag = -2.5 * np.log10(f105w_cat.segment_flux.value) + 26.2687\n",
+    "    f160w_abmag = -2.5 * np.log10(f160w_tbl['segment_flux'].value) + 26.9463\n",
+    "    \n",
+    "    yh_color = f105w_abmag - f160w_abmag\n",
+    "    print(yh_color)"
    ]
   }
  ],
@@ -147,7 +175,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR updates the Photutils notebooks, including:

* Improved text and examples
* Added a new Exercise in the overview notebook
* Required `photutils 1.1.0`
* Fixed deprecations (e.g., from numpy)