### PR TITLE
Set the schedule for AAS 238 workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,34 +15,33 @@ DO NOT WAIT UNTIL THE DAY OF THE WORKSHOP.
 
 As an alternative, a workshop session can be run on mybinder.org via this link: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stargaser/workshop-env/astropy-env/?urlpath=git-pull?repo=https://github.com/astropy/astropy-workshop%26amp%3Bbranch=main)
 
-## Preliminary Schedule
-
-Presenters to be confirmed by early May 2021.
+## Schedule
 
 **Intro to Astropy (beginners): June 4, 2021**
 | Time (EDT)        | Topic    | Presenter/Instructor |
 |-------------------|----------|-----------|
-|9:00 - 9:10am    | [Install and config](00-Install_and_Setup) help, if needed  | TBD |
-|9:10 - 9:20am | [Intro to Astropy and Code of Conduct](01-IntroCoC) | TBD |
-|9:20 - 9:40am  | [Astropy Units, Quantities, and Constants](03-UnitsQuantities) | TBD |
-|9:40 - 10:05am | [Coordinates](04-Coordinates) | TBC |
-|10:05 - 10:30am | [Intro to Object Oriented Programming (OOP)](02b-OOP) | Brett Morris (TBC) |
+|9:00 - 9:10am  | [Install and config](00-Install_and_Setup) help, if needed  | David Shupe |
+|9:10 - 9:20am  | [Intro to Astropy and Code of Conduct](01-IntroCoC) | David Shupe |
+|9:20 - 9:40am  | [Astropy Units, Quantities, and Constants](03-UnitsQuantities) | Nathaniel Starkman |
+|9:40 - 10:05am | [Coordinates](04-Coordinates) | Nathaniel Starkman |
+|10:05 - 10:30am | [Intro to Object Oriented Programming (OOP)](02b-OOP) | Brett Morris |
 |**10:30 - 10:40am**  |  **BREAK** - Have your favorite snack ready! |  |
-|10:40 - 11:10am | [I/O: FITS and ASCII](05-FITS) | TBD |
-|11:10 - 11:30am | [Astropy Tables](06-Tables)| TBD |
-|11:30 - 11:50am | [Visualizing Images with Coordinates](08-Image-coords) | TBD |
-|11:50 - 12:00pm | [Astropy Communities](10-WrapUp) | TBD |
+|10:40 - 11:00am | [I/O: FITS and ASCII](05-FITS) | Brett Morris |
+|11:00 - 11:20am | [Astropy Tables](06-Tables) | Brett Morris |
+|11:20 - 11:45am | [Cosmology](11-Cosmology) | Nathaniel Starkman |
+|11:45 - 12:00pm | [Astropy Communities](10-WrapUp) | Brett Morris |
 
 **Astronomical Research with Astropy: June 4, 2021**
-| Time (EST)        | Topic    | Presenter/Instructor |
+| Time (EDT)        | Topic    | Presenter/Instructor |
 |-------------------|----------|-----------|
-|1:00 - 1:10pm    | [Install and config](00-Install_and_Setup) help, if needed  | TBD |
-|1:10 - 1:20pm | [Intro to Astropy and Code of Conduct](01-IntroCoC) | TBD |
-|1:20 - 2:00pm | [Intro to ccdproc and guide](09c-Ccdproc) | Matt Craig (TBC) |
+|1:00 - 1:10pm | [Install and config](00-Install_and_Setup) help, if needed  | David Shupe |
+|1:10 - 1:20pm | [Intro to Astropy and Code of Conduct](01-IntroCoC) | David Shupe |
+|1:20 - 1:40pm | [Visualizing Images with Coordinates](08-Image-coords) | David Shupe |
+|1:40 - 2:00pm | [Intro to ccdproc and guide](09c-Ccdproc) | David Shupe |
 |2:00 - 2:45pm | [Photutils](09-Photutils) | Larry Bradley |
 |**2:45 - 3:00pm**  |  **BREAK** - Have your favorite snack ready! |  |
-|3:00 - 3:45pm | [Specutils](09b-Specutils) | TBD |
-|3:45 - 4:00pm | [Astropy Communities & Contributing to Astropy](10-WrapUp) | TBD |
+|3:00 - 3:45pm | [Specutils](09b-Specutils) | Ricky O'Steen |
+|3:45 - 4:00pm | [Astropy Communities & Contributing to Astropy](10-WrapUp) | Larry Bradley |
 
 ### Additional Helpers
 


### PR DESCRIPTION
Update the schedule on the top-level README.

* Transfer presenters from the planning document
* Move Visualizing Images to afternoon session before ccdproc
* Add Cosmology presentation to morning session
* Propose that @larrybradley do the closing communities (but I can do it if need be)

I think we had a lot of time for ccdproc in the last edition -- I think the afternoon organization will flow better.

cc @bmorris3 @rosteen @nstarman @larrybradley 
