### PR TITLE
fix sdss spectrum download link

### DIFF
--- a/09b-Specutils/Specutils_overview.ipynb
+++ b/09b-Specutils/Specutils_overview.ipynb
@@ -284,7 +284,7 @@
    "source": [
     "from urllib.request import urlretrieve\n",
     "\n",
-    "url = 'https://dr14.sdss.org/optical/spectrum/view/data/format=fits/spec=lite?plateid=1323&mjd=52797&fiberid=12'\n",
+    "url = 'https://data.sdss.org/sas/dr16/sdss/spectro/redux/26/spectra/1323/spec-1323-52797-0012.fits'\n",
     "urlretrieve(url, 'data/sdss_spectrum.fits')"
    ]
   },


### PR DESCRIPTION
This fixes a link that points to a sometimes-but-not-always down SDSS server with one that is more reliable.

(Please leave this PR open until after the workshop, as I conveniently can use it as an example!)