### PR TITLE
Remove cell for viewing file on disk

### DIFF
--- a/09-Photutils/photutils_overview.ipynb
+++ b/09-Photutils/photutils_overview.ipynb
@@ -837,16 +837,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# view the table file on disk\n",
-    "!cat f160w_aperture_photometry.ecsv"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1546,7 +1536,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR removes a cell that uses `!cat` to view a file on disk.  This fails for windows users (reported in today's workshop for the first time!) because `cat` is a linux command.  I've simply removed this cell because it's not that important.