### PR TITLE
Fix ccdproc notebook errors

### DIFF
--- a/09c-Ccdproc/convenience_functions.py
+++ b/09c-Ccdproc/convenience_functions.py
@@ -1,5 +1,5 @@
 from astropy import visualization as aviz
-from astropy.nddata.utils import block_reduce, Cutout2D
+from astropy.nddata import block_reduce, Cutout2D
 from matplotlib import pyplot as plt
 
 


### PR DESCRIPTION
This should fix the CI errors for the `09c-Ccdproc` `01-ccdproc-overview.ipynb` and `02-image-combination.ipynb` notebooks.