### PR TITLE
Mention lightkurve in OOP intro

### DIFF
--- a/02b-OOP/intro_to_oop.ipynb
+++ b/02b-OOP/intro_to_oop.ipynb
@@ -17,6 +17,10 @@
     "\n",
     "Instead of managing a bunch of arrays to handle these values, we could instead create an object to store light curves. \n",
     "\n",
+    "<div style=\"padding-left: 30px;\">\n",
+    "<em>Aside</em>: this tutorial will guide you through creating your own Python object to represent a light curve. The code shared here is meant as an incomplete pedagogical tool. If you work with light curves in your research, we encourage you to check out advanced existing packages for accomplishing the tasks demonstrated briefly in this notebook, and much much more, like the <strong>lightkurve</strong> package (<a href=\"https://docs.lightkurve.org/\">docs</a>, <a href=\"https://github.com/lightkurve/lightkurve\">code</a>).\n",
+    "</div>\n",
+    "\n",
     "## Defining a new object\n",
     "\n",
     "To create a new object, you use the `class` command, rather than the `def` command that you would use for functions,\n",
@@ -536,7 +540,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -550,9 +554,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/03-UnitsQuantities/Astropy_Units.ipynb
+++ b/03-UnitsQuantities/Astropy_Units.ipynb
@@ -1322,7 +1322,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1330,7 +1329,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1362,7 +1360,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1384,7 +1381,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1673,9 +1669,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "astropy-dev",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "astropy-dev"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1687,7 +1683,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.13"
   },
   "toc": {
    "base_numbering": 1,
@@ -1709,5 +1705,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/06-Tables/Advanced_Tables.ipynb
+++ b/06-Tables/Advanced_Tables.ipynb
@@ -1339,7 +1339,12 @@
     "import pandas as pd\n",
     "\n",
     "class SeriesMixin(pd.Series):\n",
-    "    info = ParentDtypeInfo()"
+    "    info = ParentDtypeInfo()\n",
+    "\n",
+    "    def __init__(self, *args, **kwargs):\n",
+    "        name = kwargs.pop('name')\n",
+    "        super().__init__(*args, **kwargs)\n",
+    "        self.info.name = name"
    ]
   },
   {
@@ -1353,8 +1358,8 @@
    },
    "outputs": [],
    "source": [
-    "s = SeriesMixin((np.arange(5)-2)**2)\n",
-    "pt = Table([s], names=['s'])"
+    "s = SeriesMixin((np.arange(5)-2)**2, name='s')\n",
+    "pt = Table([s])"
    ]
   },
   {
@@ -1433,7 +1438,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.9.13"
   },
   "nbpresent": {
    "slides": {
@@ -2495,5 +2500,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/11-Cosmology/Astropy_Cosmology.ipynb
+++ b/11-Cosmology/Astropy_Cosmology.ipynb
@@ -183,14 +183,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(astropy.cosmology.realizations.available)"
+    "from astropy.cosmology import parameters\n",
+    "\n",
+    "print(parameters.available)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From hereon we will work with the ``Planck18`` realization."
+    "From here on we will work with the ``Planck18`` realization."
    ]
   },
   {

--- a/11-Cosmology/Astropy_Cosmology.ipynb
+++ b/11-Cosmology/Astropy_Cosmology.ipynb
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,19 +56,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Attributes:  {'Ok0', 'Ob0', 'm_nu', 'has_massive_nu', 'Om0', 'Onu0', 'meta', 'hubble_time', 'Tnu0', 'Tcmb0', 'Odm0', 'hubble_distance', 'Ogamma0', 'h', 'Neff', 'H0', 'Ode0', 'critical_density0', 'name'}\n",
-      "\n",
-      "Methods:  {'arcsec_per_kpc_comoving', 'angular_diameter_distance_z1z2', 'efunc', 'kpc_comoving_per_arcmin', 'w', 'differential_comoving_volume', 'Ogamma', 'Ok', 'de_density_scale', 'Tcmb', 'lookback_time', 'Onu', 'Ode', 'lookback_distance', 'age', 'absorption_distance', 'kpc_proper_per_arcmin', 'scale_factor', 'comoving_volume', 'angular_diameter_distance', 'critical_density', 'distmod', 'inv_efunc', 'H', 'Om', 'lookback_time_integrand', 'arcsec_per_kpc_proper', 'clone', 'Tnu', 'comoving_distance', 'nu_relative_density', 'luminosity_distance', 'Ob', 'abs_distance_integrand', 'Odm', 'comoving_transverse_distance'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from astropy.cosmology import FlatLambdaCDM  # same as cosmology.FlatLambdaCDM\n",
     "\n",
@@ -95,17 +85,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Other available cosmologies: Cosmology, FLRW, LambdaCDM, FlatLambdaCDM, wCDM, FlatwCDM, w0waCDM, Flatw0waCDM, wpwaCDM, w0wzCDM\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from astropy.cosmology.core import Cosmology  # the base class\n",
     "\n",
@@ -126,20 +108,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "FlatLambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Tcmb0=2.7 K, Neff=3.04, m_nu=[0. 0. 0.] eV, Ob0=None)"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# make a realization, setting the required H0 & Om0 and overriding the default Tcmb0\n",
     "cosmo = FlatLambdaCDM(H0=70*u.km/u.s/u.Mpc, Om0=0.3, Tcmb0=2.7*u.K)\n",
@@ -155,93 +126,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$70 \\; \\mathrm{\\frac{km}{Mpc\\,s}}$"
-      ],
-      "text/plain": [
-       "<Quantity 70. km / (Mpc s)>"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cosmo.H0"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$13.96846 \\; \\mathrm{Gyr}$"
-      ],
-      "text/plain": [
-       "<Quantity 13.96846031 Gyr>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cosmo.hubble_time"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$397.8992 \\; \\mathrm{Mpc}$"
-      ],
-      "text/plain": [
-       "<Quantity 397.89919802 Mpc>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cosmo.angular_diameter_distance_z1z2(2, 4)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$[3303.5374,~5179.0432,~6354.3427,~7168.5392,~7773.0968] \\; \\mathrm{Mpc}$"
-      ],
-      "text/plain": [
-       "<Quantity [3303.53737457, 5179.04318219, 6354.34269871, 7168.53917228,\n",
-       "           7773.09684295] Mpc>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# these also work on array input\n",
     "cosmo.comoving_distance([1, 2, 3, 4, 5])"
@@ -265,19 +179,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['Planck18', 'Planck18_arXiv_v2', 'Planck15', 'Planck13', 'WMAP9', 'WMAP7', 'WMAP5']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(cosmology.parameters.available)"
+    "print(astropy.cosmology.realizations.available)"
    ]
   },
   {
@@ -289,20 +195,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "FlatLambdaCDM(name=\"Planck18\", H0=67.7 km / (Mpc s), Om0=0.31, Tcmb0=2.725 K, Neff=3.05, m_nu=[0.   0.   0.06] eV, Ob0=0.049)"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from astropy.cosmology import Planck18; Planck18"
    ]
@@ -324,20 +219,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkIAAAG1CAYAAAAV2Js8AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAA9hAAAPYQGoP6dpAABKa0lEQVR4nO3deVyUdeIH8M8wMMMNIoic3hciyC1eRRmGpXlkVKaoaOnqmkvmrtlWulvWpq6VYN6YmlFu2mUpvzJ18+AQNCIPFAXkRmE4B5h5fn+QbKTIgAPPHJ/36zUvm2cenvngI8yn5/h+JYIgCCAiIiIyQiZiByAiIiISC4sQERERGS0WISIiIjJaLEJERERktFiEiIiIyGixCBEREZHRYhEiIiIio8UiREREREbLVOwAuk6tViM/Px82NjaQSCRixyEiIiINCIKAyspKuLq6wsSk9eM+LEJtyM/Ph4eHh9gxiIiIqANyc3Ph7u7e6ussQm2wsbEB0PQXaWtrK3IaIiIi0oRCoYCHh0fz53hrWIRaERsbi9jYWKhUKgCAra0tixAREZGeaeuyFgknXb03hUIBOzs7VFRUsAgRERHpCU0/v3nXGBERERktFiEiIiIyWixCREREZLRYhIiIiMhosQgRERGR0WIRIiIiIqPFIkRERERGi0WIiIiIjBaLEBERERktFiEiIiIyWixCREREZLQ46SoRERFpXX2jGrdq6pse1Q24VVOP8poGlNfWo6KmARW1DSj/7c+Vjw2Bt5udKDlZhIiIiEgjtfUqFFfWoUihREmlEqVVTY+m/65HWbUSN6vrcbOqHpXKRo23m19eyyLUmaZMmYIff/wRDz/8MPbv3y92HCIiIp1TWdeAG+W1yC+vRX55HQor6lCoaPqzoKIWxZVKVNZpXm4AwEQC2FvK0M3SDN0sZbC3lMHe0gz2FmawszCDvaUZbC3MMMxdnBIEGEkRWrJkCebOnYtdu3aJHYWIiEgUdQ0q5N2qQc7NGuSU1SDnZi1ybtYg71YNbpTXalxyLMyk6GErh5O1HE42cjj+7k8HKxm6W8ua/rSSwdbcDCYmkk7+zu6PURShsLAw/Pjjj2LHICIi6lRqtYAb5bW4UlKFKyXVuFpShWtl1bhWWoP8iloIwr2/3t7SDG72FnCxM4eLnQV62pnDxc4cPW3N0cPWHM62cljLTSGR6Ha5aQ+dL0LHjx/Hu+++i9TUVBQUFODAgQOYPHlyi3Xi4uLw7rvvoqCgAEOHDsWGDRswZswYcQITERF1MkEQkHerFpeKKnGpqAqXiipxsbASV0urUNegbvXrrOWm8HSwhKeDJTwcLODpYAl3B0u421vA1d4CVnKdrwVap/PfcXV1NXx9fTFnzhxMmzbtjtcTEhKwdOlSxMXFYdSoUdi8eTMiIiKQmZkJT09PERITERFpT32jGpeKKpGZr0BmgQKZ+Qr8WqBo9WJkM6kEfRyt0M/JGn2drNC7uxX6OFqht6MVulvJDOpojjbofBGKiIhAREREq6+vX78e0dHRmDdvHgBgw4YNOHz4MDZt2oQ1a9a0+/2USiWUSmXzc4VC0f7QREREHaBSC7hcXIlzueU4n1eBn29U4EJBJepVdx7lMZNK0M/JGgOdbTCopw0G9Gj6b/duFjCVcphATel8EbqX+vp6pKam4m9/+1uL5eHh4Th58mSHtrlmzRqsWrVKG/GIiIjuqaK2AWev38LZnKbHudwKVN3lSI+9pRmGutrCy8UWXq62GOJii35O1jBj4blvel2ESktLoVKp4Ozs3GK5s7MzCgsLm5+PHz8eZ8+eRXV1Ndzd3XHgwAEEBQXddZsrVqxATExM83OFQgEPD4/O+QaIiMiolFYpkZR9E0nZN3Em+yYuFCruuIDZSibFMHc7+LrbN//p3s2Cp7Q6iV4Xodv++I9DEIQWyw4fPqzxtuRyOeRyudayERGR8aqsa8CZqzfx05VSnMwqw8WiyjvW6d3dEv69usHfs+kxqKcNpDp+y7kh0esi5OjoCKlU2uLoDwAUFxffcZSovWJjYxEbGwuVSnVf2yEiIuOhVgv4JV+BY5eK8ePFEqTllkOlbnnIZ3BPGwT3cWh69HZAD1tzkdISoOdFSCaTISAgAImJiZgyZUrz8sTERDzxxBP3te1FixZh0aJFUCgUsLMTb8RLIiLSbVXKRpy4VILEX4tw/FIJSqvqW7zeu7slRvZ3xKh+jhjR1wHdrXnWQZfofBGqqqpCVlZW8/Ps7Gykp6fDwcEBnp6eiImJwcyZMxEYGIjQ0FBs2bIFOTk5WLBggYipiYjIkBUp6pCYWYTEzCKculLW4q4uK5kUo/o74oFBThg7wAkeDpYiJqW26HwRSklJQVhYWPPz2xcyR0VFIT4+HpGRkSgrK8Pq1atRUFAAb29vHDp0CL169bqv9+WpMSIi+r388lp8l1GIbzMKkHL9VouLnHt3t8QjXs4IG9wDgb0cIDPl3Vz6QiIIbQ24bdxunxqrqKiAra2t2HGIiKgLlVQq8c35fHxxLh9pOeUtXvPztEe4V0884tUD/ZyseVeXjtH081vnjwgRERF1pSplI478UoiD6fn4Kau0+WJniQQI6uWAiGE98ah3T7jYWYiclLSBRYiIiIyeIAg4k30Tn6Xk4duMAtTU/++yCF8Pezzh64rHfFzgzDu8DA6LUCt4jRARkeErrKjDZym5+Cw1Dzk3a5qX93G0whPDXfHEcDf0cbQSMSF1Nl4j1AZeI0REZFjUagEnskqx9/R1fH+huPnUl5VMisd9XDE90B0Bvbrxmh89x2uEiIiIfqe8ph6fJOfi4zM5LY7+BPXuhqeDPBExrCcsZfxYNDbc40REZNAuFVVi50/XcCAtD3UNTeP92JibYpq/O54N8cRAZxuRE5KYWISIiMjgCIKAHy+VYPuJbPw3q7R5+RAXW8wZ2RsTfV1hIZOKmJB0BYtQK3ixNBGR/qlvVOOrc/nYcvxq8wSnJhIg3Ksn5ozqjeA+Drz2h1rgxdJt4MXSRES6r1rZiH1JOdh2IhuFijoATRc/Px3sidkje3OaCyPEi6WJiMjgKeoasPvUdWw7cRW3ahoAAE42cswZ1RszQnrBzsJM5ISk61iEiIhI71TUNGD7T9mI/ykbirpGAECv7pZY+EA/TPF3g9yU1/+QZliEiIhIb1TWNWDHf69h24mrqFQ2FaD+PayxOKw/HvdxgamUk51S+7AItYIXSxMR6Y6a+kbsOnkdm49fQflvp8AG97TBkocH4NGhPWFiwgugqWN4sXQbeLE0EZF46hvV+CQ5B+9/fxmlVfUAgH5OVvjLIwMxwduFBYhaxYuliYhIb6nVAr75uQBrj1zE9bKmUaA9HSyxdNwAPDHcDVIWINISFiEiItIpp66UYc23v+J8XgUAwNFahhcfHoCngz1hxmuASMtYhIiISCdcK63GW4d+xZHMIgBN4wA9P7Yf5o3pAys5P66oc/BfFhERiaqitgEffH8Zu05dQ4NKgNREgmeDPfHiuAFwtJaLHY8MHIsQERGJQqUWkJCci3cPX2geDPGBgU549bEhGMCJUKmLsAi1grfPExF1ntTrt/D6lxnIuKEA0DQW0KuPDcGDg3qInIyMDW+fbwNvnyci0p6SSiXe/vYC/nM2DwBgIzdFTPhAzBzRi4Mhklbx9nkiItIZKrWAj5Ny8K/vLqDytykxpge4Y/mjg+Fkw+uASDwsQkRE1KkyblRg5cEMnMstBwB4u9niH094w8+zm7jBiMAiREREnaRK2Yj1Ry4h/mQ21AJgLTfFy+MH4bkRvTggIukMFiEiItK6oxeKsfLAz8ivqAMAPO7jgr8/7gVnW3ORkxG1xCJERERaU1alxKqvMvHluXwAgIeDBf45eRgeGOgkcjKiu2MRIiKi+yYIAg6m38DqrzJxq6YBJhIgenQf/OWRgbCU8aOGdBf/dbaC4wgREWmmSFGHVz7/Gd9fKAYADHGxxTvThsHH3V7cYEQa4DhCbeA4QkREdycIAv5z9gZWf/ULFHWNkElN8OK4AXh+bF9Ojkqi4zhCRETUaQor6rDi8/M4erEEAODrbod3p/tiIKfGID3DIkRERBoTBAFfnsvH3w9mNB8F+ssjAzF/TB+ODE16iUWIiIg0cqu6Hq9+kYFvzhcAAHzc7bBuui8nSCW9xiJERERt+uFCEf76n59RUqmEqYkEix/qj0Vh/XktEOk9FiEiImpVbb0Kbx7KxJ7TOQCaZon/91PDMczdTuRkRNrBIkRERHf1c14FXkxIw9WSagBN4wK9PH4QzM2kIicj0h4WISIiakGlFrD5+BWsP3IJjWoBzrZyrJs+HKMHOIodjUjrWISIiKhZYUUdliak4fTVmwCAR4f2xJqpw9DNSiZyMqLOwSJEREQAgMTMIry8/xzKaxpgKZPijYlDMT3QHRIJZ4onw8UiRERk5OoaVFhz6FfsOnUdAODtZov3n/ZDXydrkZMRdT4WoVZwrjEiMgZXSqqwaO9ZXCisBADMG90HLz86CHJTXhBNxoFzjbWBc40RkaE6kJaHlQcyUFOvgqO1DGun++LBQT3EjkWkFZxrjIiI7qq2XoXXvsjAZ6l5AIDQvt3x3tPD0cPWXORkRF2PRYiIyIhcLqrEoo/P4lJRFSQS4MWHB+DPDw2A1IQXRJNxYhEiIjISB9Ly8MrnGahtUMHJRo73nh6Okf04NhAZNxYhIiIDV9egwqqvMrEvqWmajFH9u2NDpB+cbOQiJyMSH4sQEZEByymrwcK9qfglXwGJBPjzQwPw4sM8FUZ0G4sQEZGB+r/MIvzl03RU1jXCwUqGDZHDMXagk9ixiHQKixARkYFRqQWsT7yI2KNXAAD+nvaIneEPFzsLkZMR6R4WISIiA3Kzuh5L9qXhv1mlAIDZI3vjlQlDIDM1ETkZkW5iESIiMhDpueX4055U5FfUwcJMirenDcMTw93EjkWk01iEiIgMQEJyDv5+8BfUq9To42iFD58LwKCeNmLHItJ5LEJERHqsvlGNVV/9gr1nmm6Nf8TLGeue8oWtuZnIyYj0A4sQEZGeKlLU4U97zyL1+i1IJEDMuIFYFNYfJrw1nkhjLEJERHoo9fotLNiTipJKJWzMTfH+034IG8wJU4nayyhuI/j6668xaNAgDBgwANu2bRM7DhHRfUlIzsEzW06jpFKJQc42+GrxaJYgog4y+CNCjY2NiImJwdGjR2Frawt/f39MnToVDg4OYkcjImqXBpUaq7/KxO7T1wEAEd49sXa6L6zkBv+rnKjTGPwRoaSkJAwdOhRubm6wsbHBhAkTcPjwYbFjERG1S2mVEjO2nWkuQS89MhBxM/xZgojuk84XoePHj2PixIlwdXWFRCLBwYMH71gnLi4Offr0gbm5OQICAnDixInm1/Lz8+Hm9r9xNNzd3XHjxo2uiE5EpBW/5FfgiY0/ISn7Jqzlptg6KxB/fngAJBJeFE10v3S+CFVXV8PX1xcbN2686+sJCQlYunQpVq5cibS0NIwZMwYRERHIyWm6lVQQhDu+5l6/PJRKJRQKRYsHEZFYvv25AE9uOoUb5bXo3d0SBxeNxCNezmLHIjIYOl+EIiIi8M9//hNTp0696+vr169HdHQ05s2bhyFDhmDDhg3w8PDApk2bAABubm4tjgDl5eXBxcWl1fdbs2YN7Ozsmh8eHh7a/YaIiDSgVgv4d+IlLNx7FrUNKowZ4IgvFo1G/x4cJJFIm3S+CN1LfX09UlNTER4e3mJ5eHg4Tp48CQAIDg5GRkYGbty4gcrKShw6dAjjx49vdZsrVqxARUVF8yM3N7dTvwcioj+qqW/Eoo/P4r3vLwMA5o7qg52zg2BnyUESibRNr6+yKy0thUqlgrNzy8PEzs7OKCwsBACYmppi3bp1CAsLg1qtxvLly9G9e/dWtymXyyGXyzs1NxFRa/LLazFvVwoyCxQwk0rw5uRheCqIR6aJOoteF6Hb/njNjyAILZZNmjQJkyZNatc2Y2NjERsbC5VKpZWMRERtScu5hfkfpaK0SonuVjJsnhmAwN4c6oOoM+n1qTFHR0dIpdLmoz+3FRcX33GUqL0WLVqEzMxMJCcn39d2iIg08UX6DURuOY3SKiUG97TBF4tHsQQRdQG9LkIymQwBAQFITExssTwxMREjR44UKRURkebUagHrj1zEi5+ko75RjXFDemD/wpFw72YpdjQio6Dzp8aqqqqQlZXV/Dw7Oxvp6elwcHCAp6cnYmJiMHPmTAQGBiI0NBRbtmxBTk4OFixYIGJqIqK21TWo8NJn5/DN+QIAwAsP9MXy8YMh5aSpRF1G54tQSkoKwsLCmp/HxMQAAKKiohAfH4/IyEiUlZVh9erVKCgogLe3Nw4dOoRevXrd1/vyGiEi6kzFlXWY/1EqzuWWw0wqwVtThmF6IC+KJupqEuFuIw5SM4VCATs7O1RUVMDW1lbsOERkAH4tUCA6Phn5FXWwtzTD5ucCENK39btZiaj9NP381vkjQkREhuSHC0X488dpqK5Xoa+jFXbMDkJvRyuxYxEZLRYhIqIuEv9TNlZ/nQm1AIzs1x2bZgRwkEQikbEItYLXCBGRtqjUAv7xdSbiT14DAEQGeuCfU7xhJtXrG3eJDAKvEWoDrxEiovtRrWzEkn1p+P5CMQDgr48OxoIH+nLmeKJOxmuEiIhEVlhRh7nxycgsUEBuaoJ/Rw7HhGGtT/pMRF2PRYiIqBP8WqDAnJ3JKFTUwdFahi2zAuHv2U3sWET0ByxCreA1QkTUUcculWDR3rOoUjain5MV4ucEw8OBI0UT6SJeI9QGXiNERO2xLykHrx7MgEotYERfB2x+LpB3hhGJgNcIERF1IbVawNojFxH34xUAwFQ/N7w9zQcyU94ZRqTLWISIiO6TslGF5fvP44v0fADAiw8PwNJxA3hnGJEeYBEiIroPFTUNeH53Cs5k34SpiQRrpnLOMCJ9wiJERNRBebdqMHtnMrKKq2AtN8Wm5/wxZoCT2LGIqB1YhFrBu8aI6F4yblRgTnwySiqV6Glrjp1zgjDEhTdUEOkb3jXWBt41RkR/dOxSCf60JxXV9SoM7mmDnXOC4GJnIXYsIvod3jVGRNQJPk3JxYrPf4ZKLWBU/+7Y9FwAbM15ezyRvmIRIiLSgCAIeP/7LPz7/y4BACYPd8W/nvTl7fFEeo5FiIioDY0qNV49mIFPknMBAAsf7Ifl4wfx9ngiA8AiRER0DzX1jVj8cRp+uFAMEwmwatJQzAztLXYsItISFqFW8K4xIiqrUmLurhScyy2H3NQEHzzjh/ChPcWORURaxLvG2sC7xoiMU05ZDaJ2JiG7tBr2lmbYHhWIgF4OYsciIg3xrjEiog7KuFGB2TuTUVqlhJu9BXbNDUb/HtZixyKiTsAiRET0Oycul2DB7qYxgrxcbBE/Jwg9bM3FjkVEnYRFiIjoNwfTbmDZZ+fQ+NsYQR8+FwAbjhFEZNBYhIiIAGw9fhVvHvoVADDJ1xVrp3OMICJjwCJEREZNrRbw1qFfse2/2QCAuaP64NXHhsDEhGMEERkDFiEiMlr1jWos338OB9PzAQCvTBiM+WP6cqBEIiPCIkRERqla2YiFe8/i+KUSmJpI8K8nfTDV313sWETUxViEWsEBFYkMV1mVEnPjk3EurwIWZlJses4fDw7qIXYsIhIBB1RsAwdUJDIsuTdrELUjCVdLq9HN0gw7ZgfBz7Ob2LGISMs4oCIR0R9cKFRg1vYkFFc2DZT4UXQw+jlxoEQiY8YiRERGIfnaTUTHJ0NR14hBzjbYNTcYPe04UCKRsWMRIiKDl5hZhMUfn4WyUY3AXt2wPSoIdpYcKJGIWISIyMB9mpKLFZ//DJVawMODe2Djs/6wkEnFjkVEOoJFiIgM1uZjV7Dm2wsAgCcD3PH21GEwlXK0aCL6HxYhIjI4giBgzbcXsOX4VQDA82P7YkXEYA6USER3YBEiIoPSqFLjr//5Gf85mwcAWBExGC880E/kVESkq1iEiMhg1DWosPjjs/i/X4shNZFgzdRheCrQQ+xYRKTDWISIyCAo6howLz4FSdduQm5qgo3P+uMRL2exYxGRjmMRagWn2CDSHyWVSkTtSEJmgQI2clNsiwpESN/uYsciIj3AKTbawCk2iHRb7s0azNx+BtfKauBoLceuuUEY6mondiwiEhmn2CAig3exsBKzdpxBkUIJ924W2BMdgt6OVmLHIiI9wiJERHrpbM4tzNmZjIraBgxytsFH0cFwtuWUGUTUPixCRKR3jl8qwQu7U1HboIK/pz12zA6CvaVM7FhEpIdYhIhIr3xzvgBLE9LQoBIwdqATPnzOH5Yy/iojoo7hbw8i0hv7knLwyoGfIQjA4z4uWP/UcMhMOWUGEXUcixAR6YVNP17BO981zRv2bIgn/vGEN6QmnDKDiO4PixAR6TRBEPD2dxew+VjTvGF/erAfXh4/iPOGEZFWsAgRkc5SqQW8evBn7EvKBQC8MmEwnh/LecOISHtYhIhIJ9U3qvGXhHR883MBTCTAmqnDEBnkKXYsIjIwLEJEpHNq61VYsCcVxy6VwEwqwXtP+2HCMBexYxGRAWIRIiKdUlHbgOj4ZKRcvwULMyk+nBmABwY6iR2LiAwUixAR6YwWk6eamyJ+ThACejmIHYuIDBiLEBHphBvltXhu2xlkl1bD0VqGj+aGwMuVEx0TUecyipHIpkyZgm7duuHJJ58UOwoR3cWVkipM33QS2aXVcLO3wGcLRrIEEVGX0OiIkL+/f7s2KpFI8OWXX8LNza1DobRtyZIlmDt3Lnbt2iV2FCL6g4wbFYjakYSy6nr0c7LCnnkhcLGzEDsWERkJjYpQeno6XnrpJVhbW7e5riAIePvtt6FUKu87nLaEhYXhxx9/FDsGEf1ByrWbmBOfjMq6Rni72WLXnGB0t5aLHYuIjIjG1wi9/PLL6NGjh0brrlu3TuMAx48fx7vvvovU1FQUFBTgwIEDmDx5cot14uLi8O6776KgoABDhw7Fhg0bMGbMGI3fg4h0z+9nkA/q3Q3bZwfB1txM7FhEZGQ0KkLZ2dlwctL89tXMzEy4urpqtG51dTV8fX0xZ84cTJs27Y7XExISsHTpUsTFxWHUqFHYvHkzIiIikJmZCU/PpsHVAgIC7noE6siRIxrnIKKu811GAZbsS0e9So0HBjrhw+cCYCGTih2LiIyQRkWoV69eAIDGxka8+eabmDt3Ljw8PFpd/16v/VFERAQiIiJafX39+vWIjo7GvHnzAAAbNmzA4cOHsWnTJqxZswYAkJqaqvH7tUWpVLYoVQqFQmvbJiJgf2oelu8/B7UAPDbMBf+O5AzyRCSedv32MTU1xbvvvguVStVZeVqor69HamoqwsPDWywPDw/HyZMnO+U916xZAzs7u+ZHe0odEd3brpPXsOyzphL0VKA73n/GjyWIiETV7t9A48aN67ILj0tLS6FSqeDs7NxiubOzMwoLCzXezvjx4zF9+nQcOnQI7u7uSE5ObnXdFStWoKKiovmRm5vb4fxE9D+xR7Pw+pe/AADmjuqDt6f6QGrCGeSJSFztHlAxIiICK1asQEZGBgICAmBlZdXi9UmTJmkt3G0SSctfloIg3LHsXg4fPqzxunK5HHI571oh0hZBEPDOdxfx4bErAIAXHx6ApeMGtOtnmIios7S7CC1cuBBA07U7fySRSLR62szR0RFSqfSOoz/FxcV3HCXSttjYWMTGxnbZaUAiQ6RWC3j9y1+w+/R1AMDKCUMwf2xfkVMREf1Pu0+NqdXqVh/aLg0ymQwBAQFITExssTwxMREjR47U6nv90aJFi5CZmXnP02hE1LpGlRrLPjuH3aevQyIB1kwdxhJERDqn3UeEsrOz0adPH60FqKqqQlZWVovtp6enw8HBAZ6enoiJicHMmTMRGBiI0NBQbNmyBTk5OViwYIHWMhCRdikbVViyLw2HfymCqYkE657yxRPDdWOkeSKi32t3Eerfvz/Gjh2L6OhoPPnkkzA3N7+vACkpKQgLC2t+HhMTAwCIiopCfHw8IiMjUVZWhtWrV6OgoADe3t44dOhQ8y39nYWnxog6pqa+ES/sTsWJy6WQmZog7ll/jPPq3FPZREQdJREEQWjPF2RkZGDHjh3Yu3cvlEolIiMjER0djeDg4M7KKCqFQgE7OztUVFTA1paTQBLdi6KuAdHxyUi+dguWMim2zgrEqP6OYsciIiOk6ed3u68R8vb2xvr163Hjxg3s3LkThYWFGD16NIYOHYr169ejpKTkvoITkX66WV2PGVvPIPnaLdiYm2J3dAhLEBHpvHYfEfojpVKJuLg4rFixAvX19TAzM0NkZCTeeecduLi4aCunaHhEiKhtxYo6zNh2BpeLq9DdSoaPooMx1NVO7FhEZMQ67YjQbSkpKfjTn/4EFxcXrF+/HsuWLcOVK1fwww8/4MaNG3jiiSc6ummdEBsbCy8vLwQFBYkdhUin5d2qwfTNp3C5uArOtnIkvBDKEkREeqPdR4TWr1+PnTt34uLFi5gwYQLmzZuHCRMmwMTkf50qKysLgwcPRmNjo9YDdzUeESJq3dWSKszYdgYFFXXwcLDA3ugR8OxuKXYsIiKNP7/bfdfYpk2bMHfuXMyZMwc9e/a86zqenp7Yvn17ezdNRHrkQqECz21LQmmVEn2drLB3Xghc7CzEjkVE1C73fY2QoeMRIaI7ncstx6wdSaiobcAQF1vsjg6GozWnpiEi3dEpR4QUCkXzxg4dOtTi1JdUKsVjjz3WwbhEpC+Ssm9ibnwyqpSNGO5hj11zgmFnaSZ2LCKiDtG4CH399df4+9//jrS0NABAZGQkqqurm1+XSCRISEjAk08+qf2UIuCAikR3OnG5BPM/SkFdgxoj+jpgW1QQrOXtPsNORKQzNL5rbMuWLVi8eHGLZVlZWc3zjK1ZswY7duzQekCxcK4xopYSM4sQHd9Ugh4c5IT4OcEsQUSk9zQuQufPn4evr2+rr0dERCAlJUUroYhIt3x5Lh8L9qSiXqXGo0N7YvPMAJibScWORUR03zT+37nCwkJ07969+fnRo0fh4eHR/Nza2hoVFRXaTUdEovs0ORd//fw8BAGY4ueGd5/0gam0w0OQERHpFI1/mzk4OODKlSvNzwMDA2Fm9r8LJC9fvgwHBwftpiMiUe06eQ3L/9NUgp4N8cS66b4sQURkUDT+jTZ27Fi8//77rb7+/vvvY+zYsVoJpQs4sjQZu00/XsHrX/4CAIge3QdvTvaGiYlE5FRERNql8ThCaWlpCA0NxcSJE7F8+XIMHDgQAHDx4kW88847+Oabb3Dy5En4+/t3auCuxnGEyNgIgoB/J17C+z9kAQCWPNQff3lkICQSliAi0h9aH0fIz88PCQkJmDdvHj7//PMWr3Xr1g2ffPKJwZUgImMjCALeOvQrtp7IBgD89dHBWPhgP5FTERF1nnaPLF1TU4PDhw/j8uXLAIABAwYgPDwcVlZWnRJQbDwiRMZCrRbw2pcZ2HM6BwDwxkQvzB7VR+RUREQd02lzjVlaWmLKlCn3FY6IdItKLeCv/zmP/al5kEiAt6cOQ2SQp9ixiIg6nUYXS7///vuoq6vTeKMffvghKisrOxyKiLpOg0qNFz9Jw/7UPEhNJNgQOZwliIiMhkanxqRSKQoLC+Hk5KTRRm1tbZGeno6+ffved0Cx8dQYGTJlowqLP05DYmYRzKQSfPCMHx71dhE7FhHRfdPqqTFBEPDwww/D1FSzM2m1tbWapdRhnGuMDF1tvQov7EnF8UslkJua4MOZAQgb1EPsWEREXUqjI0KrVq1q94ZffPFF2NvbdySTTuERITJE1cpGRO9KxumrN2FhJsX2qECM7O8odiwiIq3R9PO73XeNGRsWITI0iroGzN6RhLM55bCWmyJ+ThACe3NUeCIyLJ121xgR6a9b1fWYtSMJP9+ogJ2FGT6aGwxfD3uxYxERiYZFiMhIlFQqMXP7GVworISDlQy7o4Mx1NVO7FhERKJiESIyAoUVdZix7TSulFSjh40ce+eFYICzjdixiIhExyJEZODybtXg2a1nkHOzBq525tg7fwT6OBrmSPBERO2l8ezzf1RfX4+LFy+isbFRm3mISIuulVYjcvNp5NysgaeDJRJeCGUJIiL6nXYXoZqaGkRHR8PS0hJDhw5FTk7TvERLlizB22+/rfWAYomNjYWXlxeCgoLEjkLUIVnFVXhq8yncKK9FXycrfPpCKDwcLMWORUSkU9pdhFasWIFz587hxx9/hLm5efPycePGISEhQavhxLRo0SJkZmYiOTlZ7ChE7XahUIGnt5xCcaUSg5xtkPB8KHrambf9hURERqbd1wgdPHgQCQkJGDFiBCQSSfNyLy8vXLlyRavhiKj9Mm5U4LntZ1Be04ChrrbYHR0CByuZ2LGIiHRSu4tQSUkJevS4cxj+6urqFsWIiLpeWs4tzNqRhMq6Rvh62OOjOcGwszQTOxYRkc5q96mxoKAgfPPNN83Pb5efrVu3IjQ0VHvJiKhdkrJv4rltZ1BZ14ig3t2wJ5oliIioLe0+IrRmzRo8+uijyMzMRGNjI9577z388ssvOHXqFI4dO9YZGYmoDSezShG9KwW1DSqM7Ncd26ICYSnj6BhERG1p9xGhkSNH4qeffkJNTQ369euHI0eOwNnZGadOnUJAQEBnZCSie/jxYjHmxCejtkGFsQOdsGN2EEsQEZGGOOlqGzjpKumyxMwiLNp7FvUqNcYN6YGNz/rD3EwqdiwiItF12qSrCoXirsslEgnkcjlkMt6dQtQVDv1cgCX70tCoFhDh3RPvPe0HmWmHx0glIjJK7S5C9vb297w7zN3dHbNnz8brr78OExP+UibqDF+k30DMp+egUguY5OuK9U/5wlTKnzciovZqdxGKj4/HypUrMXv2bAQHB0MQBCQnJ2PXrl149dVXUVJSgrVr10Iul+OVV17pjMxERm1/ah5e3n8OggA8GeCOd6b5QGrCoSuIiDqi3UVo165dWLduHZ566qnmZZMmTcKwYcOwefNmfP/99/D09MSbb77JIkSkZfuScvDKgZ8hCMAzwZ54c7I3TFiCiIg6rN3H0k+dOgU/P787lvv5+eHUqVMAgNGjRzfPQaavONcY6ZqPTl3Dis+bStDskb3x1hSWICKi+9XuIuTu7o7t27ffsXz79u3w8PAAAJSVlaFbt273n05EnGuMdMm2E1fx2he/AADmj+mD1yd6cSR3IiItaPepsbVr12L69On49ttvERQUBIlEguTkZFy4cAH79+8HACQnJyMyMlLrYYmMUdyPWfjXdxcBAIvD+uOl8IEsQUREWtKhcYSuX7+ODz/8EBcvXoQgCBg8eDBeeOEF9O7duxMiiovjCJFYBEHA+99n4d//dwkA8JdxA/HiuAEipyIi0g+afn5rdUDF9PR0DB8+XFub0wksQiQGQRCw7sglbDyaBQBY/ugg/OnB/iKnIiLSH5p+ft/3wCMVFRWIi4uDv78/p9gg0gJBEPD2txeaS9Crjw1hCSIi6iQdLkI//PADnnvuObi4uOCDDz7AhAkTkJKSos1sREZHEASs/joTm49fBQC8MdEL88b0FTkVEZHhatfF0nl5eYiPj8eOHTtQXV2Np556Cg0NDfjPf/4DLy+vzspIZBTUagGvfZmBPaebhp54c4o3ZoT0EjkVEZFh0/iI0IQJE+Dl5YXMzEx88MEHyM/PxwcffNCZ2YiMhlot4JUDP2PP6RxIJMC/pvmwBBERdQGNjwgdOXIES5YswcKFCzFgAO9cIdIWlVrAX/9zHvtT82AiAdY95Yspfu5ixyIiMgoaHxE6ceIEKisrERgYiJCQEGzcuBElJSWdmY3I4DWq1Hjp03TsT82D1ESCDU/7sQQREXUhjYtQaGgotm7dioKCArzwwgv45JNP4ObmBrVajcTERFRWVnZmTiKD06hS4y+fnsPB9HyYmkjwwTN+mOTrKnYsIiKjcl/jCF28eBHbt2/H7t27UV5ejkceeQRffvmlNvOJjuMIUWdoUKmxZF8avs0ohJlUgo3P+mP80J5ixyIiMhhdMo7QoEGD8K9//Qt5eXnYt2/f/WyKyGjUN6qxaO9ZfJtRCJnUBJtmBLAEERGJRKsjSxsiHhEibVI2qvCnPWfx/YViyExNsHlmAMIG9RA7FhGRwemykaV1XW5uLh588EF4eXnBx8cHn332mdiRyEjVNajwwu5UfH+hGHJTE2ybFcgSREQksnbPPq9vTE1NsWHDBgwfPhzFxcXw9/fHhAkTYGVlJXY0MiJ1DSrM/ygFJy6XwtzMBNujgjCqv6PYsYiIjJ7BFyEXFxe4uLgAAHr06AEHBwfcvHmTRYi6TG29CtG7knHyShksZVLsmB2EEX27ix2LiIigA6fGjh8/jokTJ8LV1RUSiQQHDx68Y524uDj06dMH5ubmCAgIwIkTJzr0XikpKVCr1fDw8LjP1ESaqVY2Yk58Ek5eKYOVTIpdc4NZgoiIdIjoR4Sqq6vh6+uLOXPmYNq0aXe8npCQgKVLlyIuLg6jRo3C5s2bERERgczMTHh6egIAAgICoFQq7/jaI0eOwNW1aVyWsrIyzJo1C9u2bbtnHqVS2WJbCoXifr49MmJVykbM3ZmMpGs3YS03xa65QQjo5SB2LCIi+h2dumtMIpHgwIEDmDx5cvOykJAQ+Pv7Y9OmTc3LhgwZgsmTJ2PNmjUabVepVOKRRx7B/PnzMXPmzHuu+8Ybb2DVqlV3LOddY9QelXUNmLMzGSnXb8FGboqPooPh59lN7FhEREbDIO4aq6+vR2pqKsLDw1ssDw8Px8mTJzXahiAImD17Nh566KE2SxAArFixAhUVFc2P3NzcDmUn46Woa8CsHUlIuX4Ltuam2DMvhCWIiEhHiX5q7F5KS0uhUqng7OzcYrmzszMKCws12sZPP/2EhIQE+Pj4NF9/tHv3bgwbNuyu68vlcsjl8vvKTcarorapBJ3LLYedhRn2zguBt5ud2LGIiKgVOl2EbpNIJC2eC4Jwx7LWjB49Gmq1ut3vGRsbi9jYWKhUqnZ/LRmnipoGzNxxBufzKtDN0gx75oVgqCtLEBGRLtPpU2OOjo6QSqV3HP0pLi6+4yiRti1atAiZmZlITk7u1Pchw1BeU48Z20/jfF4FHKxk+Hj+CJYgIiI9oNNFSCaTISAgAImJiS2WJyYmYuTIkSKlImrpVnU9nt16Bhk3FOhuJcO++SMwxIUX1hMR6QPRT41VVVUhKyur+Xl2djbS09Ph4OAAT09PxMTEYObMmQgMDERoaCi2bNmCnJwcLFiwQMTURE1uVtdjxrYz+LVAAUfrpiNBA51txI5FREQaEr0IpaSkICwsrPl5TEwMACAqKgrx8fGIjIxEWVkZVq9ejYKCAnh7e+PQoUPo1atXp+biNULUlrIqJWZsO4MLhZVwtJZj3/wQDGAJIiLSKzo1jpAu4uzzdDelVUrM2HoGF4sq4WTTVIL692AJIiLSFZp+fot+RIhI35RWKfHs1tO4VFSFHjZy7Ht+BPo5WYsdi4iIOoBFiKgdSiqbStDl4io428qxb/4I9GUJIiLSWzp915iYYmNj4eXlhaCgILGjkI74fQnqaWuOT54PZQkiItJzvEaoDbxGiACguLIOz2w5jSsl1XCxM8e++SPQ29FK7FhERNQKXiNEpCXFijo8s/V/JeiT50egV3eWICIiQ8BTY0T3UKyow9O/lSBXliAiIoPDItQKXiNEt0vQ1ZJquNlb4JPnQ1mCiIgMDK8RagOvETJORYqma4Kult4uQSPg4WApdiwiItKQpp/fPCJE9AcsQURExoNFiOh3WIKIiIwLixDRb1iCiIiMD4sQEViCiIiMFYtQK3jXmPFgCSIiMl68a6wNvGvMsBUr6vA0SxARkcHhXWNEbWAJIiIiFiEySs2DJf5WgvbNZwkiIjJGLEJkdIorm+YOu/rbtBn75o+AZ3eWICIiY8QiREalpFKJZ7ee+d3cYaEsQURERoxFqBW8a8zwNJWg08gqroKLnTn2Pc8jQURExo53jbWBd40ZhtKqphJ0qagKPW3NkfACZ5EnIjJkvGuM6DdlVUrM2HqmuQR98jxLEBERNWERIoN2s7oeM7adwcWiSjjbyrHv+RHo7cgSRERETViEyGDdqq7Hs1tP40JhJXrYyLFv/gj0YQkiIqLfYREig1Re03Qk6EJhJZxsmo4E9XWyFjsWERHpGBYhMji3S1BmgQKO1nLsmx+CfixBRER0FyxCZFAqahswc3sSfslXoLuVDPvmh6B/DxuxYxERkY5iESKDoahrwKztZ/DzjQo4WMnw8fwRGODMEkRERK1jEWoFB1TUL5V1DYjakYRzeRXoZmmGvfNCMKgnSxAREd0bB1RsAwdU1H1VykZE7UhC6vVbsLMww8fzQzDU1U7sWEREJCIOqEhGoaa+EXN3JiP1+i3Ympti7zyWICIi0hyLEOmt2noV5sYnI+naTdiYm2J3dAi83ViCiIhIcyxCpJfqGlSY91EyTl+9CWu5KT6aGwxfD3uxYxERkZ5hESK9U9egwvO7U/FTVhmsZFLsmhsEP89uYsciIiI9xCJEekXZqMLCPak4fqkEFmZS7JwTjIBeDmLHIiIiPcUiRHqjvlGNRXvTcPRiCczNTLB9diCC+7AEERFRx7EIkV5oUKmxZF8a/u/XIshNTbBtVhBG9nMUOxYREek5FiHSeY0qNWI+PYfvfimETGqCzTMDMHoASxAREd0/FiHSaSq1gOX7z+Orc/kwk0qw6Tl/PDioh9ixiIjIQLAItYJTbIhPrRaw4vPz+DztBqQmEnzwjD8eHuIsdiwiIjIgnGKjDZxiQxyCIGDlwQx8fCYHJhLg/Wf88LiPq9ixiIhIT3CKDdJbgiBg1VeZ+PhMDiQS4N+Rw1mCiIioU7AIkU4RBAFvf3sB8SevAQD+Nc0HTwx3EzcUEREZLBYh0inrEy9h8/GrAIC3pgzD9EAPkRMREZEhYxEinfHB95fxwQ9ZAIBVk4bi2RBPkRMREZGhYxEinbD52BWsS7wEAFg5YQiiRvYWNxARERkFFiESXfxP2Vjz7QUAwMvjB2H+2L4iJyIiImPBIkSi+vhMDt74KhMAsOThAVgU1l/kREREZExYhEg0+1PzsPLgzwCAF8b2xV/GDRA5ERERGRsWIRLFl+fysXz/OQgCMHtkb/wtYjAkEonYsYiIyMiwCFGX+y6jEH9JSIdaAJ4J9sTrE71YgoiISBQsQtSljl4sxp/3nYVKLWCqvxvenOzNEkRERKJhEaIuczKrFAt2p6JBJeAxHxf8a5oPTExYgoiISDwsQtQlUq7dRPSuFCgb1Rg3xBkbIofDVMp/fkREJC6D/ySqrKxEUFAQhg8fjmHDhmHr1q1iRzI65/PKMXtnMmobVBg70AmxM/xgxhJEREQ6wFTsAJ3N0tISx44dg6WlJWpqauDt7Y2pU6eie/fuYkczCr8WKDBzexKqlI0Y0dcBm58LgNxUKnYsIiIiAEZwREgqlcLS0hIAUFdXB5VKBUEQRE5lHLKKqzBz+xlU1DbA39Me26KCYCFjCSIiIt0hehE6fvw4Jk6cCFdXV0gkEhw8ePCOdeLi4tCnTx+Ym5sjICAAJ06caNd7lJeXw9fXF+7u7li+fDkcHR21lJ5ak1NWgxnbTqO0qh7ebrbYOScY1nKDPwBJRER6RvQiVF1dDV9fX2zcuPGuryckJGDp0qVYuXIl0tLSMGbMGERERCAnJ6d5nYCAAHh7e9/xyM/PBwDY29vj3LlzyM7Oxscff4yioqIu+d6MVX55LZ7ddhpFCiUGOlvjo7khsLMwEzsWERHRHSSCDp0nkkgkOHDgACZPnty8LCQkBP7+/ti0aVPzsiFDhmDy5MlYs2ZNu99j4cKFeOihhzB9+vS7vq5UKqFUKpufKxQKeHh4oKKiAra2tu1+P2NTXFmHpzefxtXSavTubolPXwhFD1tzsWMREZGRUSgUsLOza/PzW/QjQvdSX1+P1NRUhIeHt1geHh6OkydParSNoqIiKBQKAE1/KcePH8egQYNaXX/NmjWws7Nrfnh4eHT8GzAyt6rrMXNbEq6WVsPN3gJ7549gCSIiIp2m00WotLQUKpUKzs7OLZY7OzujsLBQo23k5eVh7Nix8PX1xejRo7F48WL4+Pi0uv6KFStQUVHR/MjNzb2v78FYVNY1IGpnEi4WVaKHjRx754XAzd5C7FhERET3pBdXr/5xCgZBEDSeliEgIADp6ekav5dcLodcLm9PPKNXU9+IufHJOJ9XgW6WZtg7LwS9Ha3EjkVERNQmnT4i5OjoCKlUesfRn+Li4juOEmlbbGwsvLy8EBQU1Knvo++UjSq8sDsVydduwcbcFLujQzDA2UbsWERERBrR6SIkk8kQEBCAxMTEFssTExMxcuTITn3vRYsWITMzE8nJyZ36PvqsQaXGnz9Ow4nLpbCUSRE/JwjebnZixyIiItKY6KfGqqqqkJWV1fw8Ozsb6enpcHBwgKenJ2JiYjBz5kwEBgYiNDQUW7ZsQU5ODhYsWCBialKrBbz82TkcySyCzNQE22YFIqCXg9ixiIiI2kX0IpSSkoKwsLDm5zExMQCAqKgoxMfHIzIyEmVlZVi9ejUKCgrg7e2NQ4cOoVevXp2aKzY2FrGxsVCpVJ36PvpIEAS8+kUGDqbnw9REgk0z/DGyPwepJCIi/aNT4wjpIk3HITAWgiDgrUO/YuuJbJhIgPee9sNEX1exYxEREbVgEOMIke55//ssbD2RDQB4e6oPSxAREek1FiHS2Pb/ZuPf/3cJAPDa4154KoiDTRIRkX5jEWoFb59v6dPkXPzj60wAQMwjAzF3dB+RExEREd0/XiPUBl4jBHxzvgB/3ncWagF4fmxfrIgYrPGAlkRERGLgNUKkFUcvFmNpQhrUAvBMsCdLEBERGRQWIWrVmatlWLA7FQ0qAZN8XfHPyd4sQUREZFBYhOiufs6rQPSuFCgb1Rg3pAfWPeULqQlLEBERGRYWoVYY88XSl4sqMWvHGVQpGxHatzs2PusPMyn/qRARkeHhxdJtMLaLpXNv1uDJD0+iSKGEr7sd9s4fAWu56AOQExERtQsvlqZ2K1bU4bntZ1CkUGKgszXi5wSzBBERkUFjESIAQHlNPWZuT8L1shp4OFhgd3QIulnJxI5FRETUqViECNXKRszemYyLRZXoYSPH3ugRcLY1FzsWERFRp2MRaoWxXCytbFThhd2pSM8th52FGXZHh8Czu6XYsYiIiLoEL5ZugyFfLN2oUmPxx2n47pdCWMqk2DsvBH6e3cSORUREdN94sTTdkyAIWPH5z/jul0LIpCbYOiuQJYiIiIwOi5AREgQBb37zKz5LzYOJBHj/GT+M6u8odiwiIqIuxyJkhOJ+vIJt/80GALwzzQePevcUOREREZE4WISMzJ7T1/Hu4YsAgFcfG4LpgR4iJyIiIhIPi5AR+fp8Pv7+RQYAYHFYf8wb01fkREREROJiEWqFod0+f+xSCf6SkA5BAGaEeOKl8IFiRyIiIhIdb59vgyHcPn825xZmbD2D2gYVHvdxwXtP+3EmeSIiMmi8fZ4AAJeKKjFnZzJqG1QYO9AJ658azhJERET0GxYhA5Z7swYzt59BRW0D/D3t8eFz/pCZcpcTERHdxk9FA1VapcSsHUnNM8nvmB0ESxlnkiciIvo9FiEDVFnXgKgdScgurYabvQU+mhsCe0vOJE9ERPRHLEIGpq5BhfkfpeCXfAW6W8mwOzoYPe04kzwREdHdsAgZEJVawNJP0nH66k1Yy02xa24w+jpZix2LiIhIZ7EItULfxhESBAGvHsxonkR1y6wAeLvZiR2LiIhIp3EcoTboyzhC645cxAc/ZMFEAsTN8Mej3i5iRyIiIhINxxEyIjt/ysYHP2QBAP45eRhLEBERkYZYhPTcF+k3sOqrTADAsvCBeDbEU+RERERE+oNFSI8dv1SCZZ+dAwDMHtkbi8L6i5yIiIhIv7AI6alzueVYsCcVDSoBk3xd8drjXpBIOHUGERFRe7AI6aErJVWYE5+MmnoVRvd3xNrpvjDh/GFERETtxiKkZ4oUdZi1PQk3q+vh426HD2cGcP4wIiKiDuInqB6pqG2aOuNGeS36OFphx+wgWMs5fxgREVFHsQjpidtTZ1worISTjRwfzQ2Go7Vc7FhERER6jUVID9yeOiMp+yZs5KbYNScYHg6WYsciIiLSeyxCOk4QBLz+5e+nzgiEl6vujnBNRESkT1iEWqErc4198EMW9pzOgUQCbHh6OEL7dRc1DxERkSHhXGNtEHOusU+ScvC3z38GAKx+Yihmhfbu0vcnIiLSV5xrTM8lZhbhlQNNJWhxWH+WICIiok7AIqSDUq/fwp/3nYVaAJ4KdMdL4QPFjkRERGSQWIR0TFZxFaJ3JaOuQY2HBvfAW1OGceoMIiKiTsIipEOKFHWI2pGE8poG+HrYY+OzfjCVchcRERF1Fn7K6ghF3R9GjY4KhKWMo0YTERF1JhYhHaBsVOGFj1JxobASjtZNo0Z356jRREREnY5FSGRqtYCXPzuPU1fLYCWTIn5OEEeNJiIi6iIsQiJ757sL+PJcPkxNJNj0XAC83ezEjkRERGQ0WIREtOO/2dh8/CoA4F9P+mDsQCeRExERERkXFiGRfHO+AP/4JhMAsPzRQZjq7y5yIiIiIuPDIiSCBpUa6xMvQhCAWaG9sPCBfmJHIiIiMkq8P1sEZlIT7Js/AjtPXsOy8EEcMJGIiEgkLEIi6WFrjr8+OljsGEREREbNaE6N1dTUoFevXli2bJnYUYiIiEhHGE0RevPNNxESEiJ2DCIiItIhRlGELl++jAsXLmDChAliRyEiIiIdInoROn78OCZOnAhXV1dIJBIcPHjwjnXi4uLQp08fmJubIyAgACdOnGjXeyxbtgxr1qzRUmIiIiIyFKJfLF1dXQ1fX1/MmTMH06ZNu+P1hIQELF26FHFxcRg1ahQ2b96MiIgIZGZmwtPTEwAQEBAApVJ5x9ceOXIEycnJGDhwIAYOHIiTJ0+2mUepVLbYlkKhuI/vjoiIiHSZRBAEQewQt0kkEhw4cACTJ09uXhYSEgJ/f39s2rSpedmQIUMwefJkjY7yrFixAnv27IFUKkVVVRUaGhrw0ksv4bXXXrvr+m+88QZWrVp1x/KKigrY2tq2/5siIiKiLqdQKGBnZ9fm57dOF6H6+npYWlris88+w5QpU5rXe/HFF5Geno5jx461a/vx8fHIyMjA2rVrW13nbkeEPDw8WISIiIj0iKZFSPRTY/dSWloKlUoFZ2fnFsudnZ1RWFjYKe8pl8shl8s7ZdtERESkW3S6CN32x5GXBUHo0GjMs2fP1njd2NhYxMbGQqVStft9iIiISD+IftfYvTg6OkIqld5x9Ke4uPiOo0TatmjRImRmZiI5OblT34eIiIjEo9NFSCaTISAgAImJiS2WJyYmYuTIkSKlIiIiIkMh+qmxqqoqZGVlNT/Pzs5Geno6HBwc4OnpiZiYGMycOROBgYEIDQ3Fli1bkJOTgwULFoiYmoiIiAyB6EUoJSUFYWFhzc9jYmIAAFFRUYiPj0dkZCTKysqwevVqFBQUwNvbG4cOHUKvXr06NRevESIiIjJ8OnX7vC6qqKiAvb09cnNzefs8ERGRnrg9/E15eTns7OxaXU/0I0K6rrKyEgDg4eEhchIiIiJqr8rKynsWIR4RaoNarUZ+fj5sbGyab9kPCgrSyt1k2tpOR9xuyn880nW3TK3lvFf+tr639nzvHfl74j669/K2XtPk9faup62v66ztdMTd9lF794Wu7iNt/r2KtY/a8zPUkeVtvabJ6+1d736/piu21R6d+XtOEARUVlbC1dUVJiat3xvGI0JtMDExgbu7e4tlUqlUK6fJtLWd+2Fra9siw90ytZbzXvnb+t7a87135O+J++jey9t6TZPX27uetr6us7ZzP36/j9q7L3R1H2nz71XsfaTJz1BHlrf1miavt3e9+/2arthWR3TW77l7HQm6Tadvn9dVixYt0qntaNPdMrWW81752/re2vO9d+Tvifvo3svbek2T19u7nra+rrO2oy3t3Re6uo+0+ffKfdTxTNr+mq7YljZo6/ecJnhqzEhpOgcLiYf7SPdxH+k27h/dpwv7iEeEjJRcLsfrr7/OedV0GPeR7uM+0m3cP7pPF/YRjwgRERGR0eIRISIiIjJaLEJERERktFiEiIiIyGixCBEREZHRYhEiIiIio8UiRC1UVlYiKCgIw4cPx7Bhw7B161axI9Ef5Obm4sEHH4SXlxd8fHzw2WefiR2J7mLKlCno1q0bnnzySbGjUCu+/vprDBo0CAMGDMC2bdvEjkMa6IyfK94+Ty2oVCoolUpYWlqipqYG3t7eSE5ORvfu3cWORr8pKChAUVERhg8fjuLiYvj7++PixYuwsrISOxr9ztGjR1FVVYVdu3Zh//79YsehP2hsbISXlxeOHj0KW1tb+Pv748yZM3BwcBA7Gt1DZ/xc8YgQtSCVSmFpaQkAqKurg0qlAruybnFxccHw4cMBAD169ICDgwNu3rwpbii6Q1hYGGxsbMSOQa1ISkrC0KFD4ebmBhsbG0yYMAGHDx8WOxa1oTN+rliEDMzx48cxceJEuLq6QiKR4ODBg3esExcXhz59+sDc3BwBAQE4ceJEi9fLy8vh6+sLd3d3LF++HI6Ojl2U3jhoYx/dlpKSArVaDQ8Pj05ObVy0uY+oc9zvPsrPz4ebm1vzc3d3d9y4caMrohssff25YREyMNXV1fD19cXGjRvv+npCQgKWLl2KlStXIi0tDWPGjEFERARycnKa17G3t8e5c+eQnZ2Njz/+GEVFRV0V3yhoYx8BQFlZGWbNmoUtW7Z0RWyjoq19RJ3nfvfR3Y50SySSTs1s6LTxcxMQEABvb+87Hvn5+Z0XXCCDBUA4cOBAi2XBwcHCggULWiwbPHiw8Le//e2u21iwYIHw6aefdlZEo9fRfVRXVyeMGTNG+Oijj7oiplG7n5+jo0ePCtOmTevsiEavI/vop59+EiZPntz82pIlS4S9e/d2elZjoY3Pn9Zo++eKR4SMSH19PVJTUxEeHt5ieXh4OE6ePAkAKCoqgkKhANA0K/Dx48cxaNCgLs9qrDTZR4IgYPbs2XjooYcwc+ZMMWIaNU32EYlLk30UHByMjIwM3LhxA5WVlTh06BDGjx8vRlyjoMs/N6aivjt1qdLSUqhUKjg7O7dY7uzsjMLCQgBAXl4eoqOjIQgCBEHA4sWL4ePjI0Zco6TJPvrpp5+QkJAAHx+f5nPwu3fvxrBhw7o6rlHSZB8BwPjx43H27FlUV1fD3d0dBw4cQFBQUFfHNUqa7CNTU1OsW7cOYWFhUKvVWL58Oe+O7USa/ty0pTN+rliEjNAfz4MLgtC8LCAgAOnp6SKkot+71z4aPXo01Gq1GLHod+61jwDwDiQd0NY+mjRpEiZNmtTVsYxaW/ukLZ3xc8VTY0bE0dERUqn0jvZdXFx8R0sncXAf6T7uI93HfaR7dHmfsAgZEZlMhoCAACQmJrZYnpiYiJEjR4qUin6P+0j3cR/pPu4j3aPL+4SnxgxMVVUVsrKymp9nZ2cjPT0dDg4O8PT0RExMDGbOnInAwECEhoZiy5YtyMnJwYIFC0RMbVy4j3Qf95Hu4z7SPXq7T7R2/xnphKNHjwoA7nhERUU1rxMbGyv06tVLkMlkgr+/v3Ds2DHxAhsh7iPdx32k+7iPdI++7hPONUZERERGi9cIERERkdFiESIiIiKjxSJERERERotFiIiIiIwWixAREREZLRYhIiIiMlosQkRERGS0WISIiIjIaLEIEZFRuHbtGiQSCdLT07Wybnx8POzt7Vss27JlCzw8PGBiYoINGzbcV14i6hosQkSkc2bPng2JRAKJRAJTU1N4enpi4cKFuHXrltjRmkVGRuLSpUvNzxUKBRYvXoy//vWvuHHjBp5//nk8+OCDWLp0qXghiahNnHSViHTSo48+ip07d6KxsRGZmZmYO3cuysvLsW/fPrGjAQAsLCxgYWHR/DwnJwcNDQ147LHH4OLiImIyImoPHhEiIp0kl8vRs2dPuLu7Izw8HJGRkThy5Ejz6zt37sSQIUNgbm6OwYMHIy4ursXXJyUlwc/PD+bm5ggMDERaWlqL12/duoUZM2bAyckJFhYWGDBgAHbu3NlinatXryIsLAyWlpbw9fXFqVOnml/7/amx+Ph4DBs2DADQt29fSCQSzJ49G8eOHcN7773XfHTr2rVrWvwbIiJt4BEhItJ5V69exXfffQczMzMAwNatW/H6669j48aN8PPzQ1paGubPnw8rKytERUWhuroajz/+OB566CHs2bMH2dnZePHFF1ts8+9//zsyMzPx7bffwtHREVlZWaitrW2xzsqVK7F27VoMGDAAK1euxDPPPIOsrCyYmrb81RkZGQkPDw+MGzcOSUlJ8PDwgIWFBS5dugRvb2+sXr0aAODk5NSJf0tE1BEsQkSkk77++mtYW1tDpVKhrq4OALB+/XoAwD/+8Q+sW7cOU6dOBQD06dMHmZmZ2Lx5M6KiorB3716oVCrs2LEDlpaWGDp0KPLy8rBw4cLm7efk5MDPzw+BgYEAgN69e9+RYdmyZXjssccAAKtWrcLQoUORlZWFwYMHt1jPwsIC3bt3B9BUdnr27AkAkMlksLS0bH5ORLqHRYiIdFJYWBg2bdqEmpoabNu2DZcuXcKf//xnlJSUIDc3F9HR0Zg/f37z+o2NjbCzswMA/Prrr/D19YWlpWXz66GhoS22v3DhQkybNg1nz55FeHg4Jk+ejJEjR7ZYx8fHp/m/b1/3U1xcfEcRIiL9xWuEiEgnWVlZoX///vDx8cH7778PpVKJVatWQa1WA2g6PZaent78yMjIwOnTpwEAgiC0uf2IiAhcv34dS5cuRX5+Ph5++GEsW7asxTq3T8UBgEQiAYDm9yciw8AiRER64fXXX8fatWuhUqng5uaGq1evon///i0effr0AQB4eXnh3LlzLa75uV2Sfs/JyQmzZ8/Gnj17sGHDBmzZskWrmWUyGVQqlVa3SUTaxVNjRKQXHnzwQQwdOhRvvfUW3njjDSxZsgS2traIiIiAUqlESkoKbt26hZiYGDz77LNYuXIloqOj8eqrr+LatWtYu3Zti+299tprCAgIwNChQ6FUKvH1119jyJAhWs3cu3dvnDlzBteuXYO1tTUcHBxgYsL//yTSJfyJJCK9ERMTg61bt2L8+PHYtm1b823rDzzwAOLj45uPCFlbW+Orr75CZmYm/Pz8sHLlSrzzzjsttiWTybBixQr4+Phg7NixkEql+OSTT7Sad9myZZBKpfDy8oKTkxNycnK0un0iun8SQZOT6UREREQGiEeEiIiIyGixCBEREZHRYhEiIiIio8UiREREREaLRYiIiIiMFosQERERGS0WISIiIjJaLEJERERktFiEiIiIyGixCBEREZHRYhEiIiIio8UiREREREbr/wHMKUwP0YK+ywAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
@@ -367,20 +251,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "FlatLambdaCDM(name=\"perturbed\", H0=67.7 km / (Mpc s), Om0=0.4, Tcmb0=2.725 K, Neff=3.05, m_nu=[0.   0.   0.06] eV, Ob0=0.3)"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "newcosmo = Planck18.clone(Om0=0.4, Ob0=0.3, name=\"perturbed\")  # override \n",
     "newcosmo"
@@ -395,20 +268,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAHpCAYAAAD5+R5uAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAA9hAAAPYQGoP6dpAADCPklEQVR4nOzdd1yV5f/H8dc5jMNGAUVBZDhw4sCRe5SapWVlOUrby29D7dswrbRlZZmVmdm3XZal2TRTc+XIjXsvEEHEwZR57t8fp/hFgoIC5wDv5+NxHt7nPtd93+9zULz4cN3XZTIMw0BEREREREREREREHILZ3gFERERERERERERE5P+paCsiIiIiIiIiIiLiQFS0FREREREREREREXEgKtqKiIiIiIiIiIiIOBAVbUVEREREREREREQciIq2IiIiIiIiIiIiIg5ERVsRERERERERERERB6KirYiIiIiIiIiIiIgDUdFWRERERERERERExIGoaCsilda2bdu48847CQ8Px83NDS8vL9q2bctrr73G6dOn7R3vskycOBGTyWTvGCIiIiKVlvqKYi+ZmZlMnDiR5cuXl8v5jxw5gslk4vXXXy+zcx4/fpyJEycSExNz3mv6+yZiH872DiAicik++OADRo0aRWRkJI8//jjNmjUjNzeXjRs3MnPmTNauXcv8+fPtHVNERERE7EB9RbGnzMxMJk2aBEDPnj3tG6aEjh8/zqRJkwgLC6N169aFXrvnnnu4+uqr7RNMpBpT0VZEKp21a9fy4IMP0qdPH77//nssFkvBa3369OGxxx5j4cKFdkwoIiIiIvaivqLYi2EYZGVlVdrzF6devXrUq1evwq8rUt1pegQRqXRefvllTCYTs2bNKtQJ/5urqyvXXXddwXOr1cprr71GkyZNsFgs1K5dm5EjR3Ls2LFCx23ZsoUBAwZQu3ZtLBYLQUFBXHvttYXamUwmHnroIT7++GMiIyNxd3enXbt2/PnnnxiGwZQpUwgPD8fLy4vevXtz4MCB8/J99NFHtGrVCjc3N/z8/LjhhhvYvXv3Rd93Sd+HYRi8/PLLhIaG4ubmRrt27Vi8eDE9e/Ys+E1/eno6NWrU4P777z/vOkeOHMHJyYkpU6ZcMM+kSZPo2LEjfn5++Pj40LZtWz788EMMwyjULjs7m8cee4w6derg4eFB9+7d2bRpE2FhYdxxxx2F2iYmJnL//fdTr149XF1dCQ8PZ9KkSeTl5V308xEREREB9RXVVyxaWFgYAwYMYP78+URFReHm5kZERARvv/32eW1TU1P573//S3h4OK6urgQHBzN69GgyMjIKtfv76z1z5kyaNm2KxWLh008/pVatWgWfgclkwmQyFbyXO+64g7CwsPOuWdQUBMWd/29Wq5WXXnqJ+vXrF3wtf//990LnOHDgAHfeeSeNGjXCw8OD4OBgBg4cyPbt2wvaLF++nPbt2wNw5513FmSeOHFisdlK+vetZ8+etGjRgg0bNtCtWzc8PDyIiIjglVdewWq1nvc5iMg/GCIilUheXp7h4eFhdOzYscTH3HfffQZgPPTQQ8bChQuNmTNnGrVq1TJCQkKMkydPGoZhGOnp6Ya/v7/Rrl0745tvvjFWrFhhzJkzx3jggQeMXbt2FZwLMEJDQ43OnTsb3333nTF//nyjcePGhp+fnzFmzBjj+uuvN37++Wfjyy+/NAIDA42oqCjDarUWHP/yyy8bgDFs2DDjl19+MT777DMjIiLC8PX1Nfbt21fQ7rnnnjP+/S26JO/DMAxj3LhxBmDcd999xsKFC40PPvjAqF+/vlG3bl2jR48eBe3GjBljeHp6GmfPni10nccff9xwc3MzkpOTL/i53nHHHcaHH35oLF682Fi8eLHxwgsvGO7u7sakSZMKtRs2bJhhNpuNp556yli0aJExbdo0IyQkxPD19TVuv/32gnYJCQlGSEiIERoaarz//vvGkiVLjBdeeMGwWCzGHXfcccEsIiIiIoahvqL6isULDQ01goODjfr16xsfffSRsWDBAuPWW281AGPKlCkF7TIyMozWrVsbAQEBxtSpU40lS5YYb731luHr62v07t270NcLMIKDg42oqChj9uzZxtKlS42YmBhj4cKFBmDcfffdxtq1a421a9caBw4cMAzDMG6//XYjNDT0vHxFfU2LOv+OHTuMw4cPG4AREhJidO3a1Zg3b57x7bffGu3btzdcXFyMNWvWFJxjxYoVxmOPPWbMnTvXWLFihTF//nxj0KBBhru7u7Fnzx7DMAwjJSXF+Pjjjw3AmDBhQkHmuLi4YrOV9O9bjx49DH9/f6NRo0bGzJkzjcWLFxujRo0yAOPTTz+96NdNpDpT0VZEKpXExEQDMIYOHVqi9rt37zYAY9SoUYX2r1u3zgCMp59+2jAMw9i4caMBGN9///0FzwcYderUMdLT0wv2ff/99wZgtG7dulAnbtq0aQZgbNu2zTAMwzhz5ozh7u5uXHPNNYXOGRsba1gsFmP48OEF+/7dMSrp+zh9+rRhsViMIUOGFGq3du1aAyjUET948KBhNpuNN998s2DfuXPnDH9/f+POO++84Ofwb/n5+UZubq7x/PPPG/7+/gWfw86dOw3AePLJJwu1/+qrrwygUEf8/vvvN7y8vIyjR48Wavv6668bgLFz585SZRIREZHqR31F9RWLExoaaphMJiMmJqbQ/j59+hg+Pj5GRkaGYRiGMXnyZMNsNhsbNmwo1G7u3LkGYCxYsKBgH2D4+voap0+fLtT25MmTBmA899xz5+UobdG2qPP/XbQNCgoyzp07V7A/NTXV8PPzM6666qpiP4e8vDwjJyfHaNSokTFmzJiC/Rs2bDAA4+OPP75otpL+fTMMW9EWMNatW1eobbNmzYx+/foVm1NEDEPTI4hIlbZs2TKA826t6tChA02bNi24fahhw4bUrFmTJ598kpkzZ7Jr165iz9mrVy88PT0Lnjdt2hSA/v37F7pt6O/9R48eBWzzq507d+68LCEhIfTu3fu8W5ku5X38+eefZGdnc8sttxRqd8UVV5x3G1ZERAQDBgxgxowZBbepzZ49m1OnTvHQQw8Vm+VvS5cu5aqrrsLX1xcnJydcXFx49tlnOXXqFElJSQCsWLEC4Lw8gwcPxtm58LTqP//8M7169SIoKIi8vLyCR//+/QudS0RERKSsqK9oU136is2bN6dVq1aF9g0fPpzU1FQ2b95ccJ0WLVrQunXrQtfp168fJpOJ5cuXFzq+d+/e1KxZ86LXvlQXOv+NN96Im5tbwXNvb28GDhzIypUryc/PByAvL4+XX36ZZs2a4erqirOzM66uruzfv79E024UpaR/3/5Wp04dOnToUGhfVFRUwd99ESmairYiUqkEBATg4eHB4cOHS9T+1KlTANStW/e814KCggpe9/X1ZcWKFbRu3Zqnn36a5s2bExQUxHPPPUdubm6h4/z8/Ao9d3V1veD+vxcLKGmWy3kff/8ZGBh4Xrui9j366KPs37+fxYsXA/Duu+/SqVMn2rZtW2wWgPXr19O3b1/Atjrz6tWr2bBhA+PHjwfg3LlzF8zj7OyMv79/oX0nTpzgp59+wsXFpdCjefPmACQnJ18wk4iIiIj6iuorXkidOnWK3fd3lhMnTrBt27bzruPt7Y1hGOddp6jPvCxd6PzFvZ+cnBzS09MBGDt2LM888wyDBg3ip59+Yt26dWzYsIFWrVoVfB1Kq7R/V//9tQSwWCyXfH2R6sL54k1ERByHk5MTV155Jb/++ivHjh276Cqmf3cQEhISzmt7/PhxAgICCp63bNmSr7/+GsMw2LZtG5988gnPP/887u7uPPXUU5ed/Z9Z/u3fWS71ffzd7sSJE+edIzEx8bwRFL1796ZFixZMnz4dLy8vNm/ezBdffHHR9/L111/j4uLCzz//XOi3+99//32RuU+cOEFwcHDB/ry8vPM6cwEBAURFRfHSSy8Vec2goKCL5hIREZHqTX1F9RUvJDExsdh9f2cJCAjA3d2djz76qMhz/Pvr8O8Fui7Gzc2N7Ozs8/YXV3S+0PmLez+urq54eXkB8MUXXzBy5Ehefvnl865Xo0aNUiT/f6X5dyMil04jbUWk0hk3bhyGYXDvvfeSk5Nz3uu5ubn89NNPgK2jCZzXudywYQO7d+/myiuvPO94k8lEq1atePPNN6lRo0bBrVKXq1OnTri7u5+X5dixYyxdurTILH8r6fvo2LEjFouFOXPmFGr3559/Fnv70SOPPMIvv/zCuHHjCAwM5Oabb77oezGZTDg7O+Pk5FSw79y5c3z++eeF2nXv3h3gvDxz5849b5XfAQMGsGPHDho0aEC7du3Oe6hoKyIiIiWhvuL/U1+xsJ07d7J169ZC+2bPno23t3fB6OEBAwZw8OBB/P39i7zOvwvbRbFYLAXv+d/CwsJISkoqVDjPycnht99+u+h5/+27774rGKkNkJaWxk8//US3bt0KPnuTyVSQ52+//PIL8fHxJc78b5fy70ZESk8jbUWk0unUqRPvvfceo0aNIjo6mgcffJDmzZuTm5vLli1bmDVrFi1atGDgwIFERkZy33338c4772A2m+nfvz9HjhzhmWeeISQkhDFjxgC2uatmzJjBoEGDiIiIwDAMvvvuO86ePUufPn3KJHeNGjV45plnePrppxk5ciTDhg3j1KlTTJo0CTc3N5577rlijy3p+/Dz82Ps2LFMnjyZmjVrcsMNN3Ds2DEmTZpE3bp1MZvP/13dbbfdxrhx41i5ciUTJkwouFXvQq699lqmTp3K8OHDue+++zh16hSvv/76eR3C5s2bM2zYMN544w2cnJzo3bs3O3fu5I033sDX17dQnueff57FixfTuXNnHnnkESIjI8nKyuLIkSMsWLCAmTNnXnS0jIiIiIj6iuorFicoKIjrrruOiRMnUrduXb744gsWL17Mq6++ioeHBwCjR49m3rx5dO/enTFjxhAVFYXVaiU2NpZFixbx2GOP0bFjxwtex9vbm9DQUH744QeuvPJK/Pz8CAgIICwsjCFDhvDss88ydOhQHn/8cbKysnj77bcL5qAtDScnJ/r06cPYsWOxWq28+uqrpKamMmnSpII2AwYM4JNPPqFJkyZERUWxadMmpkyZct5n1aBBA9zd3fnyyy9p2rQpXl5eBAUFFVkML+nfNxG5THZbAk1E5DLFxMQYt99+u1G/fn3D1dXV8PT0NNq0aWM8++yzRlJSUkG7/Px849VXXzUaN25suLi4GAEBAcZtt91mxMXFFbTZs2ePMWzYMKNBgwaGu7u74evra3To0MH45JNPCl0TMP7zn/8U2vf36q1TpkwptH/ZsmUGYHz77beF9v/vf/8zoqKiDFdXV8PX19e4/vrrz1vttqjVY0vyPgzDMKxWq/Hiiy8a9erVM1xdXY2oqCjj559/Nlq1amXccMMNRX6Wd9xxh+Hs7GwcO3asyNeL8tFHHxmRkZGGxWIxIiIijMmTJxsffvihARiHDx8uaJeVlWWMHTvWqF27tuHm5mZcccUVxtq1aw1fX99CK9Yahm2l3UceecQIDw83XFxcDD8/PyM6OtoYP358oVWYRURERC5GfUX1Ff8pNDTUuPbaa425c+cazZs3N1xdXY2wsDBj6tSp57VNT083JkyYYERGRhZ8HVq2bGmMGTPGSExMLGhX1Nf7b0uWLDHatGljWCwWAzBuv/32gtcWLFhgtG7d2nB3dzciIiKM6dOnF/k1Le78f/+devXVV41JkyYVfC3btGlj/Pbbb4Xanjlzxrj77ruN2rVrGx4eHkbXrl2NP/74w+jRo4fRo0ePQm2/+uoro0mTJoaLi4sBGM8995xhGJf3961Hjx5G8+bNz3sPt99+uxEaGlrkZyciNibD+GsZSBERqbIOHz5MkyZNeO6553j66acLvZaTk0NYWBhdu3blm2++qZA8a9asoUuXLnz55ZcMHz68Qq4pIiIiIkWrDn3FsLAwWrRowc8//1wm5xMRKW+aHkFEpIrZunUrX331FZ07d8bHx4e9e/fy2muv4ePjw913313Q7uTJk+zdu5ePP/6YEydOlMkCGkVZvHgxa9euJTo6Gnd3d7Zu3corr7xCo0aNuPHGG8vlmiIiIiJSNPUVRUQqBxVtRUSqGE9PTzZu3MiHH37I2bNn8fX1pWfPnrz00ksEBgYWtPvll1+48847qVu3LjNmzChYfKGs+fj4sGjRIqZNm0ZaWhoBAQH079+fyZMnF1pNWERERETKn/qKIiKVg6ZHEBEREREREREREXEg5y8NKSIiIiIiIiIiIiJ2o6KtiIiIiIiIiIiIiAOp8nPaWq1Wjh8/jre3NyaTyd5xRERERAQwDIO0tDSCgoIwmzWOoDyoHywiIiLieEraD67yRdvjx48TEhJi7xgiIiIiUoS4uDjq1atn7xhVkvrBIiIiIo7rYv3gKl+09fb2BmwfhI+Pj53TiIiIiAhAamoqISEhBX01KXvqB4uIiIg4npL2g6t80fbvW8F8fHzUWRURERFxMLptv/yoHywiIiLiuC7WD9YEYiIiIiIiIiIiIiIOREVbEREREREREREREQeioq2IiIiIiIiIiIiIA1HRVkRERERERERERMSBqGgrIiIiIiIiIiIi4kBUtBURERERuUwzZswgPDwcNzc3oqOj+eOPP4ptm5CQwPDhw4mMjMRsNjN69Ojz2nzwwQd069aNmjVrUrNmTa666irWr19fju9ARERERByJirYiIiIiIpdhzpw5jB49mvHjx7Nlyxa6detG//79iY2NLbJ9dnY2tWrVYvz48bRq1arINsuXL2fYsGEsW7aMtWvXUr9+ffr27Ut8fHx5vhURERERcRAmwzAMe4coT6mpqfj6+pKSkoKPj4+944iIiIgIVauP1rFjR9q2bct7771XsK9p06YMGjSIyZMnX/DYnj170rp1a6ZNm3bBdvn5+dSsWZPp06czcuTIIttkZ2eTnZ1d8Dw1NZWQkJAq8RmLiIiIVBUl7QdrpK2IiIiIyCXKyclh06ZN9O3bt9D+vn37smbNmjK7TmZmJrm5ufj5+RXbZvLkyfj6+hY8QkJCyuz6IiIiIlKxVLQVEREREblEycnJ5OfnExgYWGh/YGAgiYmJZXadp556iuDgYK666qpi24wbN46UlJSCR1xcXJldX0REREQqlrO9A4iIiIiIVHYmk6nQc8Mwztt3qV577TW++uorli9fjpubW7HtLBYLFoulTK4pIiIiIvaloq2IiIiIyCUKCAjAycnpvFG1SUlJ542+vRSvv/46L7/8MkuWLCEqKuqyzyciIiIilYOmRxARERERuUSurq5ER0ezePHiQvsXL15M586dL+vcU6ZM4YUXXmDhwoW0a9fuss4lIiIiIpWLRtqKiIiIiFyGsWPHMmLECNq1a0enTp2YNWsWsbGxPPDAA4Btrtn4+Hg+++yzgmNiYmIASE9P5+TJk8TExODq6kqzZs0A25QIzzzzDLNnzyYsLKxgJK+XlxdeXl4V+wZFREREpMKpaCsiIiIi7DuRxkerDvPioBY4O+lmrNIYMmQIp06d4vnnnychIYEWLVqwYMECQkNDAUhISCA2NrbQMW3atCnY3rRpE7NnzyY0NJQjR44AMGPGDHJychg8eHCh45577jkmTpxYru9HRKQ6ycu3kpGTT2ZOHhnZeZzLsZKdl092npWsXNuf2Xn55OUb5FsN8qz//6dhGIBtXnOzCUyA2WzC2WzG1dmMxdn259/b3hYXvNyc8bI44+3mjMXZXGbzn4tI1WMy/v4uU0Wlpqbi6+tLSkoKPj4+9o4jIiIi4lDyrQYf/HGIqYv2kZNvZVz/Jtzfo0G5X1d9tPKnz1hEqgvDMEg9l8fpzBxOZ9geZzJyOJ1p+zM1K5fUc3mknMv9azuXtKw80rPzyM6z2i23i5MJX3cX/D0tBHi7EuBlKdiu6+tGSE0PQvw8qOVlwWxWcVekqihpH00jbUVERESqqUMn0/nvt1vZHHsWgN5NajOoTbB9Q4mIiPzFajU4nZlDYkoWJ1KzSEzN4kRKFidSs0lOz+ZkejbJadkkp+eQk395xVdnswlPizPuLk64uZixOP//nxYXM85mE07mv/50MuFsNmECDMAwbH9aDdvo29x8g5y/Rujm5FnJybeSlWslIzuvoFgMkJtvkJyeQ3J6DntPFJ/N1dlMvRruhPh50LC2F5F1vIkM9KZRoBcerirriFRV+tctIiIiUs1YrQafrj3Cqwv3kJVrxdvizDMDm3FzdD3dpikiIhUmL99KQkoWsaczOXYmk/izWcSfOcfxs+c4nnKOhLNZpSrGelucqenpSk1PV/w8XGzbHq74urvg4+aMr4cLPm4u+Li74O3mjKerbaoCD4sTFmencnynhVmtBhk5tgLu2cxcktOzOZWRTXJajq0YnZbN8ZRzxJ0+R0LKOXLyrBxKzuBQcgYr9p0sOI/JBCE1PWha15u29WsSHVqTFsG+uLlU3HsRkfKjoq2IiIhINRJ/9hyPfRPDn4dOA9C1YQCvDo4iuIa7nZOJiEhVlJNnJe5MJodPZnA4OYPDpzKIO53J0VOZxJ89R771wjM2mkzg72mhjq+FOj5uBP71qOVtIcDLQi1v28Pf07XSFCvNZhPebi54u7kQdJH/f3PzrSSmZBF3JpPYU5nsO5HO3hOp7E1MJzk9m9jTmcSezuS3nbahuq5OZloE+xAdWpMrIvzp1MBfo3FFKin9yxURERGpJn7bmcgTc7eRci4XD1cnxl3TlNs61tfoWhERuWzp2XnsP5HG/qR0DiSls/9EGoeTM4g7c+HCrKuTmXo13ann50FwDXfq1XQnqIYbwTU8CKphK9C6VOMFMl2czIT42ea27fyvKedPpWez90QaO+JT2HT0DJuOniE5PYfNsWfZHHuWD/44jKuzmSsi/OkdWYteTWoT6u9pnzciIqWmhchEREREqris3HwmL9jNp2uPAtAqpAZvD21t1x/c1Ecrf/qMRaQ85OZbOXQygz2JqexKSGVPQhr7T6RxPCWr2GM8XJ0ID/AseNT387A9/D0I9HbTIltlxDAM4k6fY1PsaTYcOcOKvSeJP3uuUJuIAE8GRNXlhrb1CA9QAVfEHkraR1PRVkRERKQKO3gynYdnb2FXQioA93eP4LG+kbg623fUkvpo5U+fsYhcrqzcfPYkprH92Fm2HUth5/FUDiSlFzvPbG1vC40CvWhU25sGtb1oUMuTBrW8qO1t0V0ddmAYBgeS0lm2N4lle06y4chp8v4x6rl1SA1uahvMgKgganq62jGpSPWiou1f1FkVERGR6uq7zceY8P0OMnPy8fd05Y1bWtEzsra9YwHqo1UEfcYiUhr5VluBb0vsGWLibEXafSfSChX5/ubp6kSTuj40retNkzo+RNbxplFtL2p4qPDnyFKzclm2J4n5W+L5Y39ywbQVLk4mejepzZ1dwukY7qcCu0g5K2kfTXPaioiIiFQxOXlWXvh5F5//aZsOoVOEP9OGtibQx83OyURExFGkZuWy6egZNh89w5bYs8TEnSU9O++8dv6errQI9iWqni/Ng3xpVteHejXdNaVBJeTj5sL1rYO5vnUwJ9Oy+XHrceZvOcaO+FR+23mC33aeoGWwL/d0C+ealnWr9VzCIo5AI21FREREqpCTadmM+nITG46cAeDRKxvxyJWNcHKwH67VRyt/+oxF5J9OpWez4cgZ1h0+xfrDp9mdkMq/B9F6uDrRql4NWtevQat6NWhZz5cgXzeNvKzi9p1I47O1R5i76RhZubapL4J83bijSxhDO9THx83FzglFqpZKMT3CypUrmTJlCps2bSIhIYH58+czaNAgAHJzc5kwYQILFizg0KFD+Pr6ctVVV/HKK68QFBRU4muosyoiIiLVRUzcWR74fBOJqVl4W5yZNrQ1VzYNtHesIqmPVv70GYtUb+nZeaw/fIpV+0+x+kAye0+kndcmzN+DtqE1aVvf9mgc6IWzRldWW6czcvjyz6N8uvYoyenZANTwcOGhXg0Z0SkUi7OTnROKVA2VYnqEjIwMWrVqxZ133slNN91U6LXMzEw2b97MM888Q6tWrThz5gyjR4/muuuuY+PGjXZKLCIiIuKYvtkQx4Tvd5CTb6VBLU9mjWxHg1pe9o4lIiIVxGo12HrsLCv2nWT1gWS2xJ49bz7ayEBvOoT7FTw0bY78k5+nKw9f2Yh7u0fwY8xx3l95kIMnM3jxl918suYIj/eLZGBUkKbGEKkgDjM9gslkKjTStigbNmygQ4cOHD16lPr165fovBphICIiIlVZvtXghZ938cmaIwD0aRbI1Fta4e3gtzKqj1b+9BmLVH0pmbms3H+SZXuSWLHvJKcycgq9Xt/Pgy4NA+jaMIBODfzx89RCYVJy+VaDuZvimLp4HydSbSNvWwT78HT/pnRuGGDndCKVV6UYaVtaKSkpmEwmatSoUWyb7OxssrOzC56npqZWQDIRERGRipeZk8cjX21hye4kAMZc1ZiHezfUCBgRkSos7nQmv+1MZNGuE2w6eob8f4ym9bY407VRAN0b16JLgwDq+3vYMalUdk5mE0Pa1+e6VsF8tPow7y0/yI74VIb/bx3XtKzDpOtaUMvbYu+YIlVWpSnaZmVl8dRTTzF8+PALVqEnT57MpEmTKjCZiIiISMVLSs3i7k83sj0+BYuzmTeHtOaalnXtHUtERMqYYRjsO5HObzsTWbgjkV0JhQcmNQ70oldkbXo1qU10aE1cNCetlDF3Vyf+06shQ9uH8M7SA3z+51EWbE9kzcFTPDewGYNaB2uxOpFyUCmmR8jNzeXmm28mNjaW5cuXX7BoW9RI25CQEN0WJiIiIlXGvhNp3PnxBuLPnsPP05UPRrYjOrSmvWOVim7dL3/6jEUqt0Mn0/lx63F+3HqcQyczCvabTdAh3I9+zetwVdNAQvw0mlYq1o74FJ6Yu63gFwi9Imvx0g0tCarhbudkIpVDlZkeITc3l1tuuYXDhw+zdOnSi3Y4LRYLFouG54uIiEjVtGp/Mg9+sYm07DwiAjz5+M72hPp72juWiIiUgeNnz/HzNluhdkf8/4+odXU2061hAP2a1+HKprXx99LPvGI/LYJ9+eGhLsxaeYi3luxn2d6T9H1zJU9f05RhHUI06lakjDh00fbvgu3+/ftZtmwZ/v7+9o4kIiIiYjc/xMTz2DdbybMatA+ryawR7aipRWVERCq1czn5LNyZwLcbj7Hm4KmC/U5mE10bBnBdqyD6Ng90+AUmpXpxcTLzn14N6dc8kCfmbmNz7Fmenr+d1QeSeXVwFF4Why43iVQKdv1XlJ6ezoEDBwqeHz58mJiYGPz8/AgKCmLw4MFs3ryZn3/+mfz8fBITEwHw8/PD1VU/oIiIiEj18fmfR3n2hx0YBgxsFcSUwVG4uTjZO5aIiFwCwzDYEneWbzce4+etx0nLzit4rUOYHwNbB3FNizoaUSsOr2Ftb759oDMfrz7Mqwv38Mv2BHYnpvL+bdE0CvS2dzyRSs2uc9ouX76cXr16nbf/9ttvZ+LEiYSHhxd53LJly+jZs2eJrqG5vERERKSym7H8AK8t3AvAyE6hTBzYHLO5ct96qD5a+dNnLOJ4UrNy+W7TMb5cF8v+pPSC/fVqujM4uh43ta2nOWql0tp09Az/+XIzialZeLg6MfnGllzfOtjesUQcTqWY07Znz55cqGbsIGukiYiIiNiFYRi8unAvM1ccBOChXg15rG9jzRUnIlLJ7Dqeyud/HuX7LfGcy80HwM3FTP8Wdbk5uh5XRPhX+l/GiUSH1uSXR7ryyNdbWH3gFI9+HcOW2LM8fU1TXJ3N9o4nUulokhERERERB2S1Gjzzww6+XBcLwLj+Tbi/RwM7pxIRkZLKzbeyYHsCn609yqajZwr2N6rtxYhOoQxqE4yP5qmVKsbfy8Jnd3XkzcX7mL7sAJ+sOcKO+BT+d3s7anhomkuR0lDRVkRERMTB5OVb+e+3W/k+5jgmE7x8Q0uGdahv71giIlICaVm5zNkQx8erjxB/9hwAzmYT/VrUYcQVoXQM99MdE1KlOZlN/LdfJG3q12DMnBg2Hj3D4Jlr+eyuDgTVcLd3PJFKQ0VbEREREQeSbzV47Nut/BBzHGeziTeHtGZgqyB7xxIRkYtISDnHJ6uPMHtdbMHCYv6erozoFMrwDvWp7eNm54QiFevKpoHMfbAzt3+0ngNJ6dw4Yw2f3d2BxlqgTKREVLQVERERcRD5VoP//qNgO+PWtvRtXsfesURE5AKOJGcwY/kBvtscT57Vti5LRC1P7u0WwQ1tgnFzcbJzQhH7aRzozbwHOzPyr8Lt4PfW8NEd7WkX5mfvaCIOT0VbEREREQdgtRo8MXcb87fE42Q2MX14GxVsRUQc2MGT6by77AA/xBwn/69ibcdwP+7rHkGvyNpaWEzkL0E13Jn7QCfu+mQDm2PPcuv/1vHOMPVzRC5GRVsRERERO7NaDZ76bhvzNh/DyWzi7aFtuLpFXXvHEhGRIuw/kcb0ZQf4aetx/qrV0jOyFg/3bkR0aE37hhNxUDU8XPnynit4+KvNLNmdxANfbOK1wa0YHF3P3tFEHJaKtiIiIiJ2ZLUajP9+O99sPIbZBNOGtObaKDsUbHPPwe6fIermir+2iEglcOxMJlMX72P+lniMv4q1VzUN5OHeDWkVUsOu2UQqA3dXJ2beFs34+TuYszGOJ+ZuxdXZzHWau1+kSCraioiIiNiJYRhM/GknX62Pw2zCfouOxa6DH0bBqQNg8YLI/hWfQUTEQZ3OyGH60gN88edRcvKtAPRrHsjDvRvRItjXzulEKhdnJzOv3NQSs9nEV+tjGTMnBouzmX6aKkHkPCraioiIiNjJtCX7+WztUUwmmDK4Fde3Dq7YALnnYOmLsPZdwADvuuDkWrEZREQcVEZ2Hh+uOsyslYdIz84DoHMDf568uolG1opcBpPJxEuDWpCdm893W+J5ePYWZo2MpmdkbXtHE3EoKtqKiIiI2MFna4/w1u/7AXj+uubcVNFzuv1zdC1Aq+Fw9cvgrvkYRaR6s1oN5m+J59WFe0hKywageZAPT17dhG6NAjCZtMCYyOUym028NjiK7Dwrv2xP4P7PN/Hxne3p3CDA3tFEHIaKtiIiIiIV7Ketx3nux50AjL6qESM6hVXcxYsaXTvwLWjcr+IyiIg4qJi4s0z8cScxcWcBqO/nwX/7RTKgZV3MZhVrRcqSs5OZN4e0JjsvnyW7k7jn0418fncHokP97B1NxCGoaCsiIiJSgVbuO8nYb2IwDBjZKZRHr2xUcRdP2gNz74IkW8FYo2tFRGySUrN4deFe5m0+BoCnqxMP9W7EXV3DsDg72TmdSNXl6mxm+vC23PvZRv7Yn8wdH23g2wc70aSOj72jididirYiIiIiFSQm7iwPfLGJ3HyDAVF1mTiwecXcZmsYsOljWDgO8rLAsxZcNx0iry7/a4uIOLC8fCufrDnCm4v3kZGTD8CNbYN58uomBPq42TmdSPXg5uLErBHtuP2j9aw/cpq7P9nI/P90pra3/g1K9aairYiIiEgFOHgynTs/Xk9mTj7dGgUw9ZbWFXOrbeZp+OkR2P2T7XmDK+GGmeClxT5EpHrbEZ/CuO+2sz0+BYBWITWYOLAZberr7gORiubu6sSskdHcOGMNh5IzuO+zTXx93xW4uWiku1RfZnsHEBEREanqTmfkcNcnGziTmUurer7MvC0aV+cK6IYdXQMzu9oKtmYX6Psi3DpXBVsRqdYyc/J46ZddXDd9FdvjU/B2c+blG1oy/8HOKtiK2FEND1c+vKM9NTxciIk7y2PfbsVqNewdS8RuNNJWREREpBxl5+Vz/+cbOXoqkxA/dz66oz2elnLughkGrHkHljwHhhX8GsDgDyGoTfleV0TEwS3bm8SE+TuIP3sOgGuj6vLcgGbU1lQIIg4hPMCTmbdFM+LDdfyyLYGIAE8e6xtp71gidqGirYiIiEg5MQyDp+ZtZ8ORM3i7OfPR7e3x97KU70Wz0+CHh2DX97bnUUPg2qlg8Srf64qIOLC0rFye/2kX326yLTQWXMOdFwY1p3eTQDsnE5F/uyLCn5dvaMnjc7fxztIDhAd4cmPbevaOJVLhVLQVERERKSdv/36A+VvicTKbeO/WaBoFepfvBZP3w9e3QvJe23QIV0+G9vdARSx2JiLioNYcTObxb7cRf/YcJhPc2Tmcx/o2Lv+7HkTkkt3cLoRDyRm8t/wgT83bToifB+3D/OwdS6RC6X8pERERkXLwQ0w8by7ZB8CLg1rQtVFA+V5w908w/0HISQPvunDLZxDSoXyvKSLiwLJy83l14R4+Xn0EgBA/d14f3IqOEf72DSYiJfJ430iOJGfw645EHvh8Ewse7UagpjKRakQLkYmIiIiUsY1HTvP4t9sAuK97BMM61C+/i1mtsPRFmHObrWAb2gXuW6GCrYhUa1vjznLN238UFGyHdajPr492V8FWpBIxm01MvaU1Tev6cCojh4dnbyEv32rvWCIVRkVbERERkTJ07Ewm932+iZx8K32bBfLk1U3K72K552DunbByiu35FaNg5A/grTkaRaR6sloNPlh5iJveW8OhkxnU9rbw8Z3tmXxjS7w0HYJIpePu6sSMW9viZXFm/ZHTvLF4n70jiVQYFW1FREREykhWbj4PfLGJ0xk5NA/yYdrQ1jiZy2k+2fQk+GSAbcExswtcP8M2h62TS/lcT0TEwZ3OyOHuTzfw0oLd5FkNrm1Zl0VjutMrsra9o4nIZQgP8OSVm1oC8N7ygyzbk2TnRCIVQ0VbERERkTJgGAbj5+9gR3wqfp6uvD8iGg/XchrVdWIXfHAlxG8Etxow8ntoc2v5XEtEpBJYd+gU17z1B8v2nsTV2cxLN7Rg+vA21PBwtXc0ESkDA6KCGNkpFIAx38Rw/Ow5OycSKX8q2oqIiIiUgc//PMq8zccwm2D6sDbUq+lRPhfavwQ+7AspseDXAO75HcK6ls+1REQcXL7V4J3f9zPsgz9JTM0iopYnP/ynC7d2DMVkKqc7HUTELsZf25SWwb6czczlodmbydX8tlLFqWgrIiIicpnWHz7N8z/tAmBc/6Z0bhhQPhfa/BnMvuX/Fxy7ZwkENCyfa4mIOLiUzFzu+mQDbyzeh9WAG9sG89NDXWla18fe0USkHFicnXh3eFu83ZzZHHuW1xbusXckkXKloq2IiIjIZUhMyWLUl5vJsxoMbBXEPd3Cy/4ihgGr3oQfHwYjH1oNgxHfg4df2V9LRKQS2JuYxnXvrmLFvpO4uZiZMjiKqbe0xlOLjYlUafX9PZgyuBUAH/xxmCW7Ttg5kUj5UdFWRERE5BJl5+Xz4JebSE7Ppkkdb169qWXZ345rGLBoAiyZaHveZTQMeg+cNU+jiFRPv25P4IYZqzl6KpPgGu7Me7AzN7cLsXcsEakgV7eow11dbL8kf3LeNk6lZ9s5kUj5UNFWRERE5BI9/9MutsSexcfNuXwWHsvPg+9Hwdrptud9X4Q+k0DzNIpINZRvNZjy2x4e/HIzmTn5dG7gz08Pd6V5kK+9o4lIBXuyfySRgd6cyshh/PwdGIZh70giZU5FWxEREZFL8NPW43y5LhaTCd4a1oZQf8+yvUDuOfhmBGydDSYnuH4GdH64bK8hIlJJpGXlcs+nG3h32UEA7ukazmd3dcDPU3cdiFRHFmcn3rilFc5mEwt3JvJ9TLy9I4mUORVtRURERErpSHIG477bDsB/ejakV2Ttsr1Adhp8MRj2LgAnCwz5AtrcWrbXEBGpJI6fPcfNM9eybO9JLM5m3hramgkDmuHspB9nRaqzFsG+PHplIwCe/WEnCSnn7JxIpGzpfzkRERGRUsjOy+ehrzaTnp1HhzA/Rl/VqGwvkJUKX9wER1eBxQdGfAdNrinba4iIVBI74lMY9O5q9iSmUcvbwtwHOnN962B7xxIRB/Fgzwa0qudLWlYeT8zdpmkSpEpR0VZERESkFCYv2MOO+FRqerjw1rDWZTvS6++Cbdw6cPOFkT9AWNeyO7+ISCWydM8Jbnl/LUlp2TQO9OL7/3ShZT3NXysi/8/Zycwbt7TG4mzmj/3JfLku1t6RRMqMirYiIiIiJbRwRyKfrDkCwNRbWlPX173sTp6VAl/cCMfWg1sNGPkjBLctu/OLiFQin689wj2fbiQzJ5+uDQOY+2BngmuU4fdcEakyGtb24omrmwDw8oLdHD2VYedEImVDRVsRERGREog7nckTc7cCcH/3CHo1KcN5bM+dhc9vgGMbwL0m3P4jBLUuu/OLiFQShmEwecFunvlhJ1YDbmlXj4/vbI+Pm4u9o4mIA7uzcxgdw/3IzMnnsW+2km/VNAlS+aloKyIiInIROXlWHv5qC6lZebSpX4P/9ossu5OfOwOfD4L4TeDuB7f/BHVbld35RUQqiXyrwZPztvH+ykMA/LdvY169KQoXLTgmIhdhNpt4/eZWeLo6sfHoGb7486i9I4lcNv3vJyIiInIRby7ZR0zcWXzcnHlnWJuyKyBkp9nmsD2+BTz8bQXbOi3L5twiIpVIdl4+D83ezDcbj2E2wZTBUTzUuxEmk8ne0USkkgjx8+Cpa5oCMOW3vSSmZNk5kcjlUdFWRERE5AI2HDnNzBUHAXhtcBT1anqUzYlzz8FXwwqPsK3TomzOLSJSiWTm5HHPpxv5dUcirk5mZtzalpvbhdg7lohUQrd2qE/rkBqkZ+cx8ced9o4jcllUtBUREREpRlpWLmPmxGAYcHN0Pa5uUbdsTpyfC9/eCUf+AFdvuG0eBDYvm3OLXcyYMYPw8HDc3NyIjo7mjz/+KLZtQkICw4cPJzIyErPZzOjRo89rs3PnTm666SbCwsIwmUxMmzat/MKL2FFKZi4jPlzPH/uT8XB14qM72pfd91oRqXbMZhOTb2yJk9nEwp2JLN51wt6RRC6ZirYiIiIixZj00y6OnTlHvZruPDuwWdmc1JoP8x+Afb+CsxsMnwPBbcvm3GIXc+bMYfTo0YwfP54tW7bQrVs3+vfvT2xsbJHts7OzqVWrFuPHj6dVq6LnL87MzCQiIoJXXnmFOnXqlGd8Ebs5mZbNkFlr2XT0DD5uznxxT0e6NgqwdywRqeSa1vXhnm7hADz3ww4ysvPsnEjk0qhoKyIiIlKEhTsSmLvJNrfim0Na410WK5cbBiz4L+yYC2ZnuOVzCOty+ecVu5o6dSp3330399xzD02bNmXatGmEhITw3nvvFdk+LCyMt956i5EjR+Lr61tkm/bt2zNlyhSGDh2KxWIpUY7s7GxSU1MLPUQc1cm0bIZ98Cd7EtOo5W3hmwc60bZ+TXvHEpEq4tErG1GvpjvHU7J4c/E+e8cRuSQq2oqIiIj8S1JqFuO+2w7AAz0a0D7Mr2xOvGQibPwIMMGNs6Bx37I5r9hNTk4OmzZtom/fwl/Lvn37smbNmgrNMnnyZHx9fQseISGaE1Qc08m0bIZ/8CcHktKp6+vGt/d3okkdH3vHEpEqxMPVmRcG2dYK+Gj1YXbEp9g5kUjpqWgrIiIi8g+GYfD43G2cycyleZAPo69qXDYnXv02rJ5m2x44DVrcVDbnFbtKTk4mPz+fwMDAQvsDAwNJTEys0Czjxo0jJSWl4BEXF1eh1xcpieT0bG7935/sT0qnjo8bX917BWEBnvaOJSJVUK/I2lwbVRerAU/P306+1bB3JJFSUdFWRERE5B+++PMoK/adxNXZzLQhrXF1LoPu0o7vYPEztu0+z0P0HZd/TnEoJpOp0HPDMM7bV94sFgs+Pj6FHiKO5FR6Nrd+sI59J9IJ9LHw9X0q2IpI+XpuQDO83ZzZdiyFz9cesXcckVJR0VZERETkL0eSM3hpwW4Anrq6CY0CvS//pEfXwPz7bdsd7ofOj1z+OcVhBAQE4OTkdN6o2qSkpPNG34pUZ6czcrj1f+vYeyKN2t4Wvr6vkwq2IlLuavu48eTVTQB4fdE+ktKy7JxIpORUtBUREREBrFaDJ+ZtIyvXSucG/tzROezyT5q8H74aBvk50GQAXD0ZKnj0pZQvV1dXoqOjWbx4caH9ixcvpnPnznZKJeJYzmbmMPyvRcdqe1v46r4rCFfBVkQqyPAO9Ymq50t6dh6v/7bX3nFESkxFWxERERHgi3VHWX/4NB6uTrx6UxRm82UWV9OT4IubIOssBLeDGz8As1OZZBXHMnbsWP73v//x0UcfsXv3bsaMGUNsbCwPPPAAYJtrduTIkYWOiYmJISYmhvT0dE6ePElMTAy7du0qeD0nJ6egTU5ODvHx8cTExHDgwIEKfW8ilyszJ487P9nAnsQ0av1VsG1Qy8vesUSkGjGbTTw3sDkA3246xrZjZ+0bSKSEnO0dQERERMTe4k5n8sqvewB48uomhPh5XN4JczJg9hA4exRqhsPwOeB6mecUhzVkyBBOnTrF888/T0JCAi1atGDBggWEhoYCkJCQQGxsbKFj2rRpU7C9adMmZs+eTWhoKEeOHAHg+PHjhdq8/vrrvP766/To0YPly5eX+3sSKQs5eVbu/3wTW2LP4uvuwpf3dFTBVkTsIjq0Jje0CWb+lngm/riTeQ92rvC550VKy2QYRpVePi81NRVfX19SUlK0GIOIiIicxzAMRny4nlUHkukQ5sfX911xeaNsrfkw5zbYuwDc/eDuxRDQsOwCVxHqo5U/fcZiT/lWg0e+3sIv2xLwcHXii3s60rZ+TXvHEpFqLDEli95vLCczJ59pQ1ozqE2wvSNJNVXSPppdp0dYuXIlAwcOJCgoCJPJxPfff1/odcMwmDhxIkFBQbi7u9OzZ0927txpn7AiIiJSJc3ZEMeqA8lYnM28OrgMpkX4fZKtYOtkgWFfq2ArItWOYRg888MOftmWgIuTiZm3RatgKyJ2V8fXjf/0svXLJv+6m4zsPDsnErkwuxZtMzIyaNWqFdOnTy/y9ddee42pU6cyffp0NmzYQJ06dejTpw9paWkVnFRERESqooSUc7z0y24AHu8XefkL42ydA6vfsm0PmgH1O15mQhGRyueNRfuYvS4WkwneHNKa7o1r2TuSiAgAd3cNp76fBydSs3lv+UF7xxG5ILsWbfv378+LL77IjTfeeN5rhmEwbdo0xo8fz4033kiLFi349NNPyczMZPbs2cWeMzs7m9TU1EIPERERkX8zDIOnv9tOWnYeberX4M4u4Zd3wvhN8OPDtu2uY6Hl4MsPKSJSyXy46jDTl9kWzHtxUAsGRAXZOZGIyP9zc3Fi/LVNAZj1xyFiT2XaOZFI8exatL2Qw4cPk5iYSN++fQv2WSwWevTowZo1a4o9bvLkyfj6+hY8QkJCKiKuiIiIVDLzt8SzbO9JXJ3MTBkchdPlTIuQmgBf3wr52dC4P/R+puyCiohUEr9uT+CFn3cBtrsXbu0YaudEIiLn69sskK4NA8jJs/LSgl32jiNSLIct2iYmJgIQGBhYaH9gYGDBa0UZN24cKSkpBY+4uLhyzSkiIiKVz+mMnILCwqNXNaJhbe9LP1luFsy5FdISoFYTuHEWmB22iyUiUi62xJ5h9JwYAEZ2CmVUzwb2DSQiUgyTycSzA5vhZDbx284TrD6QbO9IIkVy+J8oTKbCo14Mwzhv3z9ZLBZ8fHwKPURERET+6eUFuzmTmUuTOt7c1z3i0k9kGPDTo7apEdxqwLCvwE19DxGpXuJOZ3LvZxvJzrPSu0ltnh3Q7II/s4mI2FvjQG9GXGG7G+DFX3ZjtRp2TiRyPoct2tapUwfgvFG1SUlJ542+FRERESmptQdPMXfTMUwmePnGlrg4XUZ3aO102PY1mJzglk/B7zIKwCIilVDKuVzu+mQDyek5NKvrwzvD2uB8Od9XRUQqyKNXNsLbzZndCal8HxNv7zgi53HY/03Dw8OpU6cOixcvLtiXk5PDihUr6Ny5sx2TiYiISGWVnZfP+O+3AzC8Q33a1q956Sc7sgoWP2fb7vcyRPS8/IAiIpVIbr6VUV9uYn9SOnV83PjojvZ4WpztHUtEpERqeroyqmdDAN5YtI+s3Hw7JxIpzK5F2/T0dGJiYoiJiQFsi4/FxMQQGxuLyWRi9OjRvPzyy8yfP58dO3Zwxx134OHhwfDhw+0ZW0RERCqp91cc4tDJDAK8LDxxdZNLP1FaIsy9C4x8iBoCHe8vu5AiIpWAYRhMmL+D1QdO4eHqxId3tKOOr5u9Y4mIlMqdXcKo6+tG/NlzfLb2iL3jiBRi16Ltxo0badOmDW3atAFg7NixtGnThmeffRaAJ554gtGjRzNq1CjatWtHfHw8ixYtwtv7MhYLERERkWrpcHIG05cdAODZgc3wdXe5tBPl59kKtuknoFZTGPAmaO5GEalmZq08xJyNcZhNMH14G5oH+do7kohIqbm5OPFY30gApi89wNnMHDsnEvl/di3a9uzZE8Mwznt88skngG0RsokTJ5KQkEBWVhYrVqygRYsW9owsIiIilZBhGEz4fjs5eVa6NQpgYFTdSz/Z0ufh6Gpw9YIhn4OrZ9kFFRGpBFbsO8krC/cA8NzA5vRuojVHRKTyuqFNME3qeJOalce7f/2CX8QROOyctiIiIiJl5YeY46w+cAqLs5kXB7W49FXN9/wCq9+ybV8/HQIalV1IEZFK4OipDB6evRnDgKHtQxjZKdTekURELouT2cS4a5oC8Omao8SdzrRzIhEbFW1FRESkSkvJzOXFX3YB8HDvhoT6X+LI2NOHYP6Dtu2OD0LzG8oooYhI5ZCRncd9n20iNSuPNvVrMOn65pf+SzAREQfSvVEAXRr6k5Nv5Y1Fe+0dRwRQ0VZERESquNcX7SU5PYeGtb24r3uDSztJ7jn4ZiRkp0C9DtDn+bINKSLi4AzD4PG5W9l7Io1a3hZm3haNxdnJ3rFERMqEyWRiXH/baNvvY46zIz7FzolEVLQVERGRKmzn8RS+XHcUgOevb46r8yV2fX4bD4nbwcMfbv4EnF3LLqSISCXw3oqDLNieiIuTiZm3tSXQx83ekUREylSLYF8GtQ4CYPKvuzEMw86JpLpT0VZERESqJMMwmPjjTqwGDIiqS+cGAZd2ot0/wcYPbds3fgC+wWUXUkSkEli2N4kpv9luF554XXOiQ/3snEhEpHw81jcSVyczqw+c4o/9yfaOI9WcirYiIiJSJf0Qc5wNR87g7uLE+GubXtpJUuLhx4dt250fhoZXll1AEZFKIPZUJo9+tQXDgGEdQri1oxYeE5GqK8TPg9uusH2fe33RXo22FbtS0VZERESqnPTsPF5esBuAh3o3pK6ve+lPYs2H7+6Dc2egbmvo/WzZhhQRcXDZefk89NXmgoXHJl7X3N6RRETK3aheDfBwdWLbsRQW7Tph7zhSjaloKyIiIlXOO7/vJyktmzB/D+7pFn5pJ1k1FY6uAhdPGPyR5rEVkWpn8oI9bDuWQg0PF6YPb6uFx0SkWgjwsnBXF1v/ceqifeRbNdpW7ENFWxEREalSDiSl89HqwwA8O7DZpRUZ4tbDssm27WtfB/8GZZhQRMTxLdyRwCdrjgDwxs2tCK5xCXcsiIhUUvd2j8DHzZm9J9L4aetxe8eRakpFWxEREakyDMNg0k87yc036N2kNr2bBJb+JFkpMO9uMPKh5c3QaljZBxURcWBxpzN5fO42AO7rHsGVTS/he6mISCXm6+7C/T1sv7R/c8k+cvOtdk4k1ZGKtiIiIlJlLNp1gj/2J+PqZObZAc1KfwLDgJ/HwNlYqBEK104Fk6nsg4qIOKicPCsPzd5M2l/z2D7eL9LekURE7OKOzmEEeLly9FQmczcds3ccqYZUtBUREZEqISs3nxd+3gXAvd3DCQvwLP1Jts+FHfPA5AQ3fQhuPmWcUkTEsb3y6x62HkvB1902j62Lk35kFJHqydPizKieDQF4+/f9ZOXm2zmRVDf6H1hERESqhA9XHebYmXPU8XHjP70alv4EqcdhwWO27R5PQkj7sg0oIuLgftuZWDAnuOaxFRGB4R3rU9fXjYSULL5cF2vvOFLNqGgrIiIild7JtGxmLDsAwJP9I/FwdS7dCQwDfnjINp9tUBvoNrYcUoqIOK7ElCye+Gse23u7hXNVM81jKyLi5uLEI1c2AmDGsgNkZOfZOZFUJyraioiISKU3dfE+MnLyiarny/Wtgkt/go0fwcHfwdkNbngfnFzKPqSIiIOyWg3+++1WUs7lElXPl8f7NbF3JBERhzE4uh5h/h6cysjhkzVH7B1HqhEVbUVERKRS25OYypwNttvVnhnQDLO5lAuHnT4Ei56xbV/5HNTSojsiUr18vOYIqw4k4+Zi5s0hrXF11o+JIiJ/c3EyM6ZPYwDeX3GQlHO5dk4k1YX+NxYREZFKyzAMXvplN1YDrmlZh/ZhfqU7gTUf5j8IuRkQ1g06PlA+QUVEHNTexDReXbgHgPHXNqNBLS87JxIRcTwDo4JoVNuL1Kw8Pll9xN5xpJpQ0VZEREQqreV7T/LH/mRcncw8efUl3M67djrE/Qmu3nD9u2BW10hEqo/svHxGz4khJ89Kr8ha3Naxvr0jiYg4JLPZxKNX2ea2/d+qQxptKxVCP5mIiIhIpZSbb+XFX3YBcEeXMEL9PUt3ghO7YOmLtu2rX4aaoWWcUETEsU1dvI/dCan4ebry6uAoTKZSTi8jIlKNXNOiLo0DvUjLyuPj1YftHUeqARVtRUREpFL6en0sB09m4Ofpyn96NSzdwfl58P0DkJ8DjfpBmxHlE1JExEH9eegUs1YeAuCVG1tS29vNzolERByb2Wzi0Sttc9t+uOqwRttKuVPRVkRERCqdlHO5vLlkPwBjrmqEr7tL6U6w9h1I2ApuNeC6t0Gjy0SkGknNyuWxb7ZiGDC0fQh9m9exdyQRkUqhf4s6RAZ6k5aVx0erNNpWypeKtiIiIlLpzFh2gNMZOTSs7cWwDqWcgzF5PyybbNu+ejJ4q1ghItXL8z/tIv7sOUL9PXhmQDN7xxERqTT+ObftR6sOk5Kp0bZSflS0FRERkUrl2JlMPv5r1d6nr2mCs1MpujNWK/z4MORnQ4Pe0GpY+YQUEXFQy/cmMXfTMUwmmHpLKzwtzvaOJCJSqVzdvA5N6niTlp3Hh5rbVsqRirYiIiJSqUxdvI+cfCudIvzpFVm7dAdv/BBi14KLJwyYpmkRRKRaScvK5envtgNwV5dwokP97JxIRKTysc1taxtt+7FG20o5UtFWREREKo3dCanM3xIPwFP9m5RupfOzsbBkom37qolQM7TM84mIOLLJv+7heEoWof4e/LdvpL3jiIhUWv3+Odp21SF7x5EqSkVbERERqTReW7gHw4Bro+rSKqRGyQ80DPh5DOSkQ8gV0P6ecssoIuKI1hxIZva6WABeuTEKd1cnOycSEam8zGYTo/+e23b1Ec5m5tg5kVRFKtqKiIhIpbD24CmW7T2Js9lU+hFiW7+GA0vAyQLXTwezukAiUn1k5uTx5HfbALjtivp0auBv50QiIpVf32Z1aFrXh/TsPD5cpbltpezpJxYRERFxeIZh8MqvuwEY1qE+4QGeJT84PQkWPmXb7vkkBDQqh4QiIo5rym97iTt9juAa7jzVv6m944iIVAn/nNv2k9VHSDmnuW2lbKloKyIiIg7v1x2JbD2WgoerE49cWcqi68JxkHUW6rSEzo+USz4REUe18chpPllzBICXb2yJl8XZvoFERKqQvs0CiQy0zW37yeoj9o4jVYyKtiIiIuLQcvOtTPltLwD3douglrel5Acf+B12zAWTGa57B5xcyimliIjjycrN54l52zAMGBxdjx6Na9k7kohIlWI2m3j4yoYAfLT6MGlZGm0rZUdFWxEREXFoX2+I43ByBgFertzbPaLkB+aeg18es213uA+C2pRPQBERBzVj+UEOncyglreFZ65tZu84IiJVUv8WdWlQy5OUc7l8tvaoveNIFaKirYiIiDisjOw83lqyH4BHrmxUutt6/5gKZw6Dd13oNb6cEoqIOKZDJ9OZufwgAJOua46vh+40EBEpD05mEw/3tk3f9eGqw2Rk59k5kVQVKtqKiIiIw/po1WGS07MJ9fdgaPv6JT/w5D5Y9aZt++pXwM2nfAKKiDggwzB45ocd5ORb6dG4Fv1b1LF3JBGRKm1AVF3C/D04nZHDl+s02lbKhoq2IiIi4pDOZuYwa+UhAMb2aYyrcwm7LYYBv4wFay406gvNri/HlCIijufHrcdZfeAUFmczz1/fHJPJZO9IIiJVmrOTmVG9bHPbzlp5mKzcfDsnkqpARVsRERFxSO+vPERadh5N6ngzMCqo5AdumwNH/gBnd7hmCqhYISLVSMq5XF74eRcAD/duSKi/p50TiYhUDze0CaZeTXeS07P5an2sveNIFaCirYiIiDicpLQsPll9BID/9o3EbC5h4TXzNPz21/y1PZ6AmmHlkk9ExFG9/ttektNzaFDLs3SLN4qIyGVxcTIzqqdttO3MFQc12lYum4q2IiIi4nBmLDvIudx8WofU4MqmtUt+4JKJkJkMtZpC54fLLZ+IiCOKiTvLF3/NpfjCoBZYnJ3snEhEpHq5KTqYIF83TqRm8+2mY/aOI5WcirYiIiLiUI6dyWT2OtstZY/3iyz5XIxxG2Dzp7btAW+Ck1ZKF5HqIy/fyvj52zEMuLFNMJ0bBNg7kohItWNxduKBng0AeG/ZAXLyrHZOJJWZirYiIiLiUN7+fT85+VY6N/CnS8MSFh2s+bDgv7bt1rdCaKfyCygi4oA+//MoO4+n4uPmzNPXNrV3HBGRauuWdiHU9rZwPCWL7zZrtK1cOhVtRURExGEcOpnOvM3xAPy3X2TJD9z8GSTEgMUXrppYLtlERBzVybRspi7aB8CT/ZsQ4GWxcyIRkerLzcWJ+/6aU/y9FQfJy9doW7k0KtqKiIiIw3hzyX7yrQZXNqlN2/o1S3ZQ5mn4fZJtu9fT4FWKOXBFRKqA13/bS1p2HlH1fBnWvr6944iIVHvDO9bHz9OVo6cy+Xlbgr3jSCWloq2IiIg4hF3HU/lp63EAHutbilG2S1+Ec2egdjNof085pRMRcUzbj6XwzaY4AJ4b2ByzuYTzgIuISLnxcHXm7q7hAExfdgCr1bBzIqmMVLQVERERhzB18V4ABkTVpVmQT8kOStgKGz+ybfd/DZycyymdiIjjMQyDST/txDBgUOsgokNLeIeCiIiUu5GdQvFxc+ZAUjq/7Uy0dxyphFS0FREREbuLiTvLkt1JOJlNjO3TuGQHGQYseBwwoMVNEN6tXDOKiDiaH7ceZ+PRM7i7OPFUfy0+JiLiSLzdXLijcxhgG21rGBptK6Wjoq2IiIjY3ZuLbQvo3NAmmIhaXiU7aNsciFsHLp7Q54VyTCci4ngyc/J45dc9APynVwPq+LrZOZGIiPzbnV3C8XB1YufxVJbvPWnvOFLJqGgrIiIidrXp6BlW7DuJk9nEw70bluygrFRY9Ixtu8fj4BtcfgFFRBzQzOUHSUjJol5Nd+7pFmHvOCIiUoSanq6MuCIUgLeX7tdoWykVFW1FRETErqYtsY2yHdy2HqH+niU7aMWrkJEEfg3gilHlmE6kZGbMmEF4eDhubm5ER0fzxx9/FNs2ISGB4cOHExkZidlsZvTo0UW2mzdvHs2aNcNisdCsWTPmz59fTumlsok7ncn7Kw8BMOHapri5ONk5kYiIFOfubuFYnM1siT3L2oOn7B1HKhGHLtrm5eUxYcIEwsPDcXd3JyIigueffx6r1WrvaCIiIlIGNh45zR/7k3E2m3iopKNskw/Aupm27f6vgrOl/AKKlMCcOXMYPXo048ePZ8uWLXTr1o3+/fsTGxtbZPvs7Gxq1arF+PHjadWqVZFt1q5dy5AhQxgxYgRbt25lxIgR3HLLLaxbt64834pUEq/8uofsPCudIvzp17yOveOIiMgF1PZ2Y1iH+gC8s/SAndNIZeLQRdtXX32VmTNnMn36dHbv3s1rr73GlClTeOedd+wdTURERMrAm3+Nsr25XT1C/DxKdtCiCWDNg0b9oFGfckwnUjJTp07l7rvv5p577qFp06ZMmzaNkJAQ3nvvvSLbh4WF8dZbbzFy5Eh8fX2LbDNt2jT69OnDuHHjaNKkCePGjePKK69k2rRpxebIzs4mNTW10EOqnj8PneKX7QmYTfDswGaYTCZ7RxIRkYu4r3sELk4m1h46xcYjp+0dRyoJhy7arl27luuvv55rr72WsLAwBg8eTN++fdm4caO9o4mIiMhlWnfoFKsPnMLFycR/epVwlO3BpbDvVzA7Q98XyzegSAnk5OSwadMm+vbtW2h/3759WbNmzSWfd+3ateeds1+/fhc85+TJk/H19S14hISEXPL1xTFZrQYv/bIbgOEd69O0ro+dE4mISEkE1XDnprb1AJi+TKNtpWQcumjbtWtXfv/9d/bts43C2bp1K6tWreKaa64p9hiNMBAREakc/h5le0u7EOrVLMEo2/w8WPi0bbv9vVCrcTmmEymZ5ORk8vPzCQwMLLQ/MDCQxMTESz5vYmJiqc85btw4UlJSCh5xcXGXfH1xTD9tO872+BS8LM6MuUrfA0VEKpMHezbAbILle0+yIz7F3nGkEnDoou2TTz7JsGHDaNKkCS4uLrRp04bRo0czbNiwYo/RCAMRERHHt/bgKf48dBpXJ3PJR9lu/gRO7gb3mtDjiXLNJ1Ja/75F3TCMy75tvbTntFgs+Pj4FHpI1ZGdl8+U3/YCth/8/b00n7eISGUS6u/J9a2DAZiuuW2lBBy6aDtnzhy++OILZs+ezebNm/n00095/fXX+fTTT4s9RiMMREREHJthGAWjbId2CCGohvvFDzp3Fpa+ZNvuNR48/MovoEgpBAQE4OTkdN4I2KSkpPNGypZGnTp1yvycUrl9vvYox86cI9DHwl1dwu0dR0RELsGong0AWLgzkX0n0uycRhydQxdtH3/8cZ566imGDh1Ky5YtGTFiBGPGjGHy5MnFHqMRBiIiIo5t7cFTrD98GldnM6N6lnCU7YrX4NxpqNUEou8s34AipeDq6kp0dDSLFy8utH/x4sV07tz5ks/bqVOn8865aNGiyzqnVF4pmbkFK46P7dMYd1cnOycSEZFL0SjQm/4t6gAwQ3PbykU42zvAhWRmZmI2F64rOzk5YbVa7ZRIRERELsc/R9kO71CfOr5uFz8o+QCsf9+23e8lcHLo7otUQ2PHjmXEiBG0a9eOTp06MWvWLGJjY3nggQcA251g8fHxfPbZZwXHxMTEAJCens7JkyeJiYnB1dWVZs2aAfDoo4/SvXt3Xn31Va6//np++OEHlixZwqpVqyr8/Yn9zVhxgJRzuTQO9CpYyEZERCqn//RqyK87Evlx63FGX9WYsABPe0cSB+XQP/UMHDiQl156ifr169O8eXO2bNnC1KlTueuuu+wdTURERC7B2kOn2HDkDK7OZh786/awi1o0Aax50KgfNLyqfAOKXIIhQ4Zw6tQpnn/+eRISEmjRogULFiwgNDQUgISEBGJjYwsd06ZNm4LtTZs2MXv2bEJDQzly5AgAnTt35uuvv2bChAk888wzNGjQgDlz5tCxY8cKe1/iGOLPnuPj1UcAeKp/E5ydHPpmSRERuYgWwb70iqzFsr0nmbniIK/cFGXvSOKgTIZhGPYOUZy0tDSeeeYZ5s+fT1JSEkFBQQwbNoxnn30WV1fXEp0jNTUVX19fUlJSNFWCiIiInQ2dtZY/D53m9k6hTLq+xcUPOLgMPh8EZmd4cC3U0mrpVYX6aOVPn3HV8Ng3W5m3+RhXRPjx1b1XXPYCdyIiYn+bjp7mpvfW4uJkYsXjvUq2xoNUGSXtozn0r2m9vb2ZNm0aR48e5dy5cxw8eJAXX3yxxAVbERERcRzrDp3iz0OncXUy80BJRtla822jbAHa36OCrYhUO7uOp/LdlmMAjOvfVAVbEZEqIjrUjysi/MjNN5i18pC944iDcuiirYiIiFQdfy+ic3O7etT1LcFogq1fw4kdYPGFHk+WczoREcfzysI9GAYMiKpLq5Aa9o4jIiJl6OHejQD4an0sJ9Oy7ZxGHJGKtiIiIlLuNh09zaoDyTibTSWbyzYnE5a+YNvu/l/w8CvfgCIiDmbNgWRW7juJi5OJx/tF2juOiIiUsc4N/GkdUoPsPCv/W6XRtnI+FW1FRESk3L39u22U7eDoetSr6XHxA/58F9ISwLc+dLivnNOJiDgWwzB4fdFeAIZ3qE+ov1YWFxGpakwmEw/3bgjAF2uPcjYzx86JxNGoaCsiIiLlKibuLCv2ncTJbGJUz4YXPyA9CVZNs21f9Ry4uJVrPhERR7N870k2x57FzcXMf3qV4PumiIhUSr2b1KZpXR8ycvL5aPURe8cRB6OirYiIiJSrd37fD8ANbYKp71+CUbbLJ0NOOgS1heY3lnM6ERHH8s9Rtrd3CqO2j35xJSJSVZlMJh7665dzn6w+TFpWrp0TiSNR0VZERETKzY74FH7fk4TZRMlGi53cC5s+tW33fRHM6qqISPXy285Edh5PxdPVift7lGAOcBERqdSublGHBrU8Sc3K47O1R+0dRxyIfhISERGRcvP2X6Nsr28dTHhACeZkXPwcGPkQeS2EdSnndCIijiXfajB18T4A7u4ajp+nq50TiYhIeXMym3jor7ltP1x1mMycPDsnEkehoq2IiIiUi13HU1m06wSmko6yPfwH7PsVTE7QZ1L5BxQRcTA/bzvOvhPp+Lg5c3e3CHvHERGRCjIwKohQfw9OZ+Qwe12sveOIg1DRVkRERMrFu8sPAHBty7o0rO114cZWKyyaYNtudycENCrndFLdODk52TuCyAXl5Vt5869Rtvf3aICvu4udE4mISEVxdjIzqqdtSpz3Vx4iKzffzonEEahoKyIiImXuQFI6C7YnABTc7nVBO7+DhBhw9YYeT5VvOKmWDMOwdwSRC/puczxHTmXi5+nKHZ3D7B1HREQq2A1t6hFcw52Tadl8szHO3nHEATjbO4CIiIhUPTOWH8AwoE+zQJrU8blw47wcWPqCbbvLo+BVq/wDSqW3YMGCC75+zTXXFHpuMpnKM47IZcnOy+etv+YAH9WzAZ4W/ZgmIlLduDqbeaBHBM/8sJOZyw8ytH19XJ011rI6U29AREREylTc6Ux+iDkOwEMlmct20ydw5gh41oZOo8o1m1Qd3377LQBJSUmsWbOGK6+8EsMwWLZsGT169DivaCviyL7ZEEf82XPU9rZw2xWh9o4jIiJ2cnO7EN5ZeoDjKVl8t/kYQzvUt3cksaMSFW1//PHHUp+4T58+uLu7l/o4ERERqdzeW3GQfKtBt0YBtAqpceHG2Wmw4lXbds+nwNWz3PNJ1fDxxx8DMHDgQHbv3k2dOnUASExM5MEHH7zgsevWraN27dqEh4ezatUq/vzzTyIjIxk4cGC55xb5t6zcfKYvs80B/nDvhri5aP5lEZHqys3Fifu6R/DiL7uZsfwgg6Pr4eyk0bbVVYmKtoMGDSrVSU0mE/v37yciQiueioiIVCeJKVnM3XgMgId7l2AxsTXTITMZ/BpA25HlnE6qooMHD1Kr1v9PqeHv78/evXuLbf/oo4+yadMm8vLyuOqqq1i9ejXXXnst77//PkuXLuXNN9+siNgiBb7dGMeJ1GyCfN24pX2IveOIiIidDe9YnxnLDxJ7OpMftx7nxrb17B1J7KTE0yMkJiZSu3btErX19va+5EAiIiJSec1aeYicfCsdwvzoEO534cbpSbDmHdv2lc+Ck1ZKl9K76aab6Ny5MzfccAMmk4n58+czePDgYtsvWbKEHTt2kJ2dTb169YiPj8disTBmzBhat25dccFFgJw8K+8tPwjAAz0bYHHWKFsRkerOw9WZe7qF89rCvUxfdoDrWwfjZNbc/NVRicZY33777aWa6uC2227Dx+cii46IiIhIlXIqPZvZ648C8FDvEsxlu+I1yM2A4Ghodn05p5Oq6oUXXmD69Om4u7tjsVh45513eP7554ttbzKZyMvLIzs7m9zcXLKysgDIz88nPz+/omKLAPDd5mMcT8mitreFW9pplK2IiNiMuCIUX3cXDp3MYMH2BHvHETsp0Ujbv+cMK6n33nvvksKIiIhI5fXhqsNk5VppVc+Xbo0CLtz49CHY9Ff/4qpJYNLoAbl0VquVWrVqMXz4cE6fPs2xY8eoV6/oWwnvvvtumjZtSn5+Pi+99BJDhgyhUaNGrFmzhhtvvLGCk0t1lpdvZcZfo2zv6x6huWxFRKSAt5sLd3UJ580l+3hn6X6ubVkXs0bbVjslnh4BIC8vDzc3N2JiYmjRokV5ZRIREZFKJiUzl8/W2kbZ/qdXQ0wXK8IufRGsedDwKgjvVgEJpaqaOHEimzdvZs+ePQwfPpxz584xdOhQVq1aVWT7MWPGMGLECAACAgK47bbbWLJkCbfddhsdO3asyOhSzf0Qc5zY05n4e7pya8dQe8cREREHc0eXMP636hD7TqSzcGci17Ssa+9IUsFKtQSds7MzoaGhunVMRERECvl07RHSs/NoUsebq5oGXrjx8S2wYx5ggqsmVkQ8qcK+//57fvjhBzw9PQEIDg4mLS3tgscEBAQQEGAbDV6jRg0GDx5Mx44d2bRpU7nnFQHItxq8u+wAAPd0i8DdVaNsRUSkMF93F+7sEg7A27/vx2o17JxIKlqpirYAEyZMYNy4cZw+fbo88oiIiEglk5Gdx0erDwMwqlfDi9+6tWSi7c+oW6BOy/INJ1WexWIBKBjdffbs2YuP9C7GDTfcUGa5RC7kl+0JHErOoIaHCyM6aZStiIgU7a4uYXhZnNmTmMaiXSfsHUcqWKmmRwB4++23OXDgAEFBQYSGhhaMavjb5s2byyyciIiIOL7Z62I5m5lLeIAn117stq1DK+DQcjC7QK+nKySfVG0PPvggQ4YM4eTJk7z44ovMmTOHJ598stj2t9xyS5H7DcPQoASpEFarwfSl+wG4q0s4XpZS/0gmIiLVRA0PV+7oHMb0ZQd4+/f99GseeMm/nJbKp9Q9hEGDBpVDDBEREamMsnLz+eCPQwA82KMBThcaZWsY8Psk23a7O6FmWPkHlCrvjjvuoGPHjvz+++8AfP311zRv3rzY9kuWLOHzzz/Hy8ur0H7DMFi5cmW5ZhUBWLQrkX0n0vG2OHN75zB7xxEREQd3d9dwPl59mF0JqSzZnUSfZheZikyqjFIXbZ977rnyyCEiIiKV0LzNx0hKy6aurxuD2gRfuPGeXyB+E7h4QPfHKyagVHmGYbBz504OHjyI2Wymbt26NGvWrNhRKD179sTLy4sePXqc91qbNm3KO65Uc4Zh8M5S21y2d3QJw9fdxc6JRETE0dX0dGVk5zDeW36Qt3/fz1VNa2u0bTVR6jlt77jjDo1CEBEREfLyrcxccRCA+7pH4Op8gW6FNR+WvmDbvuJB8KpdAQmlOrj//vv54osv6NChA+3atePLL7/k/vvvL7b9d999V2TBFmDhwoXlFVMEgKV7kth5PBVPVyfu+mtxGRERkYu5p2s47i5ObI9PYdneJHvHkQpS6pG2aWlp9O3bl5CQEO68805uv/12goMvMrJGREREqpyftyUQd/ocfp6uDG1f/8KNt82Bk3vArQZ0fqRC8kn1sHbtWrZv317wfOjQoURFRRXb/qeffmLVqlWMGjWK0FAtACUVa8Zy2y+6busUSk1PVzunERGRysLfy8LITqG8v/IQb/1+gF6RGm1bHZR6pO28efOIj4/noYce4ttvvyUsLIz+/fszd+5ccnNzyyOjiIiIOBir1WDGctstvnd3Dcfd1an4xnnZsGyybbvraHCvUe75pPqIiooiJiam4PnWrVvp2LFjse0HDhzI7bffzk8//cTHH39cAQlFbDYeOc2mo2dwdTJzd1eNshURkdK5p1sEbi5mtsadZcW+k/aOIxWg1EVbAH9/fx599FG2bNnC+vXradiwISNGjCAoKIgxY8awf//+ss4pIiIiDmTx7hMFC+mM6HSR0YqbPoGUWPCqAx2Kv21dpDTat29Phw4d2LFjB9HR0TRp0oQmTZoQHR3N5s2bL3hss2bNGDBgAHfeeWeh/evXry/PyFLN/T2dzE3RwdT2drNzGhERqWxqeVu4raOt3/3W7/sxDMPOiaS8lXp6hH9KSEhg0aJFLFq0CCcnJ6655hp27txJs2bNeO211xgzZkxZ5RQREREHYRgGM5bZRtmO7ByKj9sFFtLJToeVU2zbPR4HV48KSCjVwdy5cwHIzs7GYrGU+vibb76ZuXPnFkyRsGjRIp544olCo3ZFysq+E2ks2Z2EyQT3douwdxwREamk7usRwed/HmVLrG20bc9IrRNRlZW6aJubm8uPP/7Ixx9/zKJFi4iKimLMmDHceuuteHt7A/D111/z4IMPqmgrIiJSBa0+cIqtx1JwczFz58UW0ln3HmSchJph0GZkheST6iE0NBSr1Urbtm0vqdD60UcfMXjwYL799lvWrVvHG2+8wW+//Vb2QUWAWSsPAdCvWR0iannZOY2IiFRWtb3dGHFFKP9bdZg3l+ynR+Namtu2Cit10bZu3bpYrVaGDRvG+vXrad269Xlt+vXrR40aNcognoiIiDiad/8aZTu0fX0CvC4wwjHzNKx+x7bdazw4a9EdKVtms5kOHTqwc+dOmjdvXqpjW7ZsyUcffcS1115L7dq1WbJkCT4+PuWUVKqzhJRz/BATD8D9PTTKVkRELs/9PRrw5bpYtsadZdneJHo3CbR3JCknpS7avvnmm9x88824uRU/D1PNmjU5fPjwZQUTERERx7Pp6BnWHjqFs9nEfd0vUnxY/RZkp0Dt5tBicMUElGpn/fr1tGnThsaNG+Ph4YFhGJhMpmLnp23fvn2hESlnz57FZDJx1VVXFZxPpCx9tOowufkGHcP9aFO/pr3jiIhIJVfL28LITqG8v/IQby7eT6/I2hptW0WVumg7YsSI8sghIiIilcB7y22jbG9sG0xQDffiG6adgHXv27Z7TwDzJa19KnJRP/zwQ6na/z0XrkhFSMnMZfa6WAAe6NnAzmlERKSquK+7bW7b7fEpLNmdRJ9mGm1bFZX4J6iEhATGjx9f8Lxr1660bdu24NG+fXvi4+PLJaSIiIjY357E1IKFdB7ocZHiwx9vQN45CG4Hkf0rJqBUS6GhoUU+Ltb+/fffx9fXt+C5j48Ps2bNqsDkUh18se4oGTn5NKnjTc/GtewdR0REqgh/Lwu3dw4DYOrifVithn0DSbkocdF2xowZnD17tuD51q1b6datG9dffz3XX389Tk5OvPnmm+WRUURERBzAe8sPAnBNi7oXXkjnbBxs+ti2feUzoNu1pBx99tlnRT4u5tdffy20BkPNmjX59ddfyzGpVDdZufl8vNo2Zdz9PSJ066qIiJSp+7pF4OnqxO6EVBbtSrR3HCkHJZ4e4aeffmLKlCmF9j366KNERNjms7viiisYO3Ysr7/+etkmFBEREbs7eiqDn7YeB+DBi93iu+JVyM+BsG4Q0bP8w0m1tn379oLt7OxsFi9eTFRUFCNHjrzgcfn5+aSnp+PlZfsFRGpqKrm5ueWaVaqXeZuPkZyeQ3ANdwZEBdk7joiIVDE1PV25q2s47yw9wLQl++nbrA5ms35BWJWUuGh75MgRGjT4/x/S+vTpg6enZ8HzyMhILT4mIiJSRb2/8hBWA3o0rkWLYN/iG546CDGzbdtXPlsx4aRa+/eggvT0dIYOHXrR4x5++GG6dOnCkCFDMAyDb775htGjR5dTSqlu8q0GH6w8BMDdXcNxcdK83iIiUvbu6RrBJ6uPsCcxjV93JHJtVF17R5IyVOLeQ15eHikpKQXPv/vuOwID/3+i4zNnzmDWIiMiIiJVTlJqFnM3HgNg1MVG2S57GYx8aNQPQjpUQDqRwkwmE/v27btou3vvvZcvvvgCb29vfHx8mD17NnfffXcFJJTqYPGuRI6cysTX3YUh7UPsHUdERKooXw8X7uoaDsC0JfvI19y2VUqJq6yRkZGsWbOm2Nf/+OMPGjduXCahRERExHH8b9VhcvKtRIfWpEO4X/ENE3fAjrm27d4TKiacVHvt27enQ4cOdOjQgejoaBo1asSoUaNKdGxqaip+fn74+vqyadOmEs2FK1ISH66y3YF42xX18bSU+OZGERGRUrurazg+bs7sT0rn523H7R1HylCJexBDhw7l2WefpVu3bkRFRRV6bevWrUyaNImnnnqqzAOKiIiI/aRk5vLln0cB+E+vBhdeSGfZS7Y/m98AdaOKbydShm644QZuvfVWAJydnalVqxZvvPHGRY8bNmwYiYmJtGnTBicnJwAtFCVlYtuxs2w4cgYXJxMjO4XZO46IiFRxvu4u3NMtgqmL9zFtyX6ubVkXZ03LUyWUuGg7evRofv75Z6Kjo+nTpw+RkZGYTCb27NnD4sWL6dSpk+YBExERqWI+XXuEjJx8mtTxpldk7eIbHtsIexeAyQw9n664gFLtzZ07l6efLvx37uuvv2bcuHEXPG7r1q3s2rWrPKNJNfX3KNsBUUEE+rjZOY2IiFQHd3UN55M1RzicnMG8zccY0r6+vSNJGShx6d3FxYXFixfzwgsvcPz4cd5//31mzpxJfHw8L7zwAosXL8bFxaU8s4qIiEgFyszJ4+PVtuLDgz0vMsp26Qu2P1sNg1qaLknK3wcffED79u3Zu3dvwfQIHTp0oGnTpjRv3vyix3fo0IH9+/dXQFKpThJTsvhlWwIAd3UJt3MaERGpLrwszgVrT7y1ZD9Zufl2TiRloVQTLLm6uvLUU09pGgQREZFq4Kv1cZzJzCXU34NrW15gJdojq+DQcjC7QI8nKyyfVG+33HILffr04emnn2by5MkF+729vfHzu8Dcy3+JiYmhZcuWREZGYrFYMAwDk8nE+vXryzO2VHGfrT1CntWgQ5gfLev52juOiIhUI7ddEcr//jjM8ZQsZq+LLVigTCovzYovIiIi58nJs/LBykMA3N+9QfHzYhkGLH3Rtt12JNQMraCEUt35+vri7e3Nrl27CA0t/d+7H374oRxSSXV2Lief2etjAfSDsoiIVDg3FycevaoR477bzrvLDjCkfYgWw6zkSjQ9gp+fH8nJySU+af369Tl69OglhxIRERH7mr/lGImpWdT2tnBTdHDxDQ/+DrFrwdkNuj9ecQFFALPZTIcOHdi5c2epjw0NDSU0NBQ3NzdMJlPBQ+RSzdt8jLOZudT386BPs0B7xxERkWpocHQ9wvw9OJWRUzDNmVReJSq5nz17ll9//RVf35Ld4nPq1Cny8zV/hoiISGWUbzWYucI2yvaebuFYnJ2KbvjPUbbt7wGfC0yhIFJO1q9fT5s2bWjcuDEeHh4lnubg+++/Z9y4ccTFxRESEsK+ffuIiopiy5YtFZRcqhKr1eCjv344vqNzGE5m/QJAREQqnouTmTF9GvPo1zG8v/IQt10RSg0PV3vHkktU4nHSt99+e3nmEBEREQfx644EDidn4OvuwvCOF7jtfO8COL4FXDyh65iKCyjyD5c6zcGzzz7LunXr6N69OzExMaxfv5733nuvjNNJdbFi30kOnczA2+LMLe1D7B1HRESqsYFRQby3/CB7EtN4f+Uhnry6ib0jySUq0fQIVqu11I+IiIjyzi4iIiJlzDAMZiw7CNhGi3kVNw+W1QpLX7JtX/EgeAZUUEKRwkJDQ0lMTGT16tWEhobi4+ODk1Mxo8P/wWKx4OPjA0BOTg4dOnRg69at5R1Xqqi/R9kOaR9S/PdNERGRCmA2m/hv30gAPl59mKS0LDsnkktVoqKtiIiIVA/L951kV0IqHq5O3NE5rPiGO7+DpJ1g8YXOD1VYPpF/mzhxIi+99BITJ04EIDMzk6FDh170uLp163L27FkGDhzINddcw5AhQ6hVq1Y5p5WqaG9iGn/sT8Zsgtsv9H1TRESkglzZtDZt6tcgK9fKu0sP2DuOXCKHL9rGx8dz22234e/vj4eHB61bt2bTpk32jiUiIlIlvffXKNvhHepT07OY+a/y82D5ZNt254fBvWYFpRM53/fff88PP/yAp6cnAMHBwaSmpl70uB9//JEaNWrwwgsvMGHCBG699VZ+/PHH8o4rVdBHq2yjbPs1r0OIn4ed04iIiIDJZOLxfrbRtrPXxxJ3OtPOieRSOPS9O2fOnKFLly706tWLX3/9ldq1a3Pw4EFq1Khh72giIiJVzoYjp1l/5DQuTibu6XaBaY62zYFTB8DdD654oOICihTBYrEAth9OwLaArtlcunEJPXv2LOtYUk2cychhfkw8AHd3DbdzGhERkf/XuUEAXRsGsOpAMm8s2su0oW3sHUlKyaGLtq+++iohISF8/PHHBfvCwsLsF0hERKQKm7HMduvU4Oh61PF1K7pRXg6seMW23XUMWLwrKJ1I0R588EGGDBlCcnIyL774InPmzOHJJ58stn379u0LCrxFWb9+fXnElCpqzsY4cvKstAj2ITpUdx2IiIhjefLqJqyavorvY45zT7cIWgT72juSlIJDF21//PFH+vXrx80338yKFSsIDg5m1KhR3HvvvcUek52dTXZ2dsHzktweJyIiUt3tPJ7Csr0nMZvg/u4Nim+45XM4GwtegdD+nooLKFKMO+64g44dO/L7779jGAZff/01zZs3L7b93LlzKzCdVGX5VoMv/jwKwMgrwi74ywARERF7aFnPl+tbB/FDzHEm/7qbL+7uqP+vKhGHLtoeOnSI9957j7Fjx/L000+zfv16HnnkESwWCyNHjizymMmTJzNp0qQKTioiIlK5vbfcNpfttVFBhAV4Ft0o9xysnGLb7vZfcNXcjeIYmjZtStOmTUvUNjAwkJkzZ3LgwAFatmzJ3XffjbOzQ3eJxUEt25PEsTPn8HV3YWCrIHvHERERKdJ/+0by6/ZEVh84xcr9yfRorIVXKwuHXojMarXStm1bXn75Zdq0acP999/Pvffey3vvvVfsMePGjSMlJaXgERcXV4GJRUREKp/DyRks2J4AwIM9LjDKduPHkJYAPvUg+vYKSidyYYZhMHfuXMaOHctjjz3GvHnzMAyj2PYjR45k48aNtGzZkl9//ZXHHnusAtNKVfLZX6Nsh7QPwd3Vyc5pREREihbi58GITqEAvPLrHvKtxfeTxLE49LCCunXr0qxZs0L7mjZtyrx584o9xmKxFCxIISIiIhf3/oqDWA3o3aQ2zYJ8im6UnQ6rptq2ezwBzvq/VhzD/fffT1JSEkOGDAHgyy+/5LfffmPWrFlFtt+9ezfbt28H4O6776ZDhw4VllWqjsPJGazcdxKTCW7rGGrvOCIiIhf0UK+GfLMxjt0JqXy/JZ6bouvZO5KUgEMXbbt06cLevXsL7du3bx+hoeoYiYiIlIWElHPM23wMgFE9LzDKdv0syDgJNcOh9fAKSidycWvXri0owgIMHTqUqKioYtu7uLgUbGtaBLlUn6+1jbLtFVmb+v6aKkZERBxbTU9XRvVsyKsL9zB18T6ujaqLm4vuEnF0lzw9woEDB/jtt984d+4cwAVvQ7tUY8aM4c8//+Tll1/mwIEDzJ49m1mzZvGf//ynzK8lIiJSHX2w8jC5+QYdwvxoF+ZXdKOsFFj9lm275zhwcim6nYgdREVFERMTU/B869atdOzYsdj227Zto3bt2tSuXZtatWqxffv2gu3atWtfco4ZM2YQHh6Om5sb0dHR/PHHHxdsv2LFCqKjo3FzcyMiIoKZM2cWej03N5fnn3+eBg0a4ObmRqtWrVi4cOEl55Oyk5mTx7ebbFOw/X27qYiIiKO7s0sYdX3diD97js/WHrF3HCmBUhdtT506xVVXXUXjxo255pprSEiwzYF3zz33lPmcYO3bt2f+/Pl89dVXtGjRghdeeIFp06Zx6623lul1REREqqNT6dnMXm8bLfaf3g2Lb7h2BmSdhYBIaDm4YsKJlNCOHTto164dTZo0oUmTJkRHR7Np0ybat29f5NQHeXl5JCUlkZSUxMmTJ8nNzS3YTkpKuqQMc+bMYfTo0YwfP54tW7bQrVs3+vfvT2xsbJHtDx8+zDXXXEO3bt3YsmULTz/9NI888kihKcAmTJjA+++/zzvvvMOuXbt44IEHuOGGG9iyZcslZZSy8/2W46Rl5RHq70GPRlrMRUREKgc3FyfG9mkMwPSlBzibmWPnRHIxJqOUQ2RHjhxJUlIS//vf/2jatClbt24lIiKCRYsWMWbMGHbu3FleWS9Jamoqvr6+pKSk4ONTzDx9IiIi1dDrv+1l+rIDtAz25ceHumAymc5vlHkapkVBThrc/Ck0H1ThOaVqKqs+2tGjRy/4+t/TapnNZqxW6yVf50I6duxI27ZtCy2W27RpUwYNGsTkyZPPa//kk0/y448/snv37oJ9DzzwAFu3bmXt2rUABAUFMX78+EJ3mA0aNAgvLy+++OKLInNkZ2eTnZ1d8Dw1NZWQkBD1g8uQYRj0f+sP9iSmMeHaptzTLcLekUREREos32pw7du2/8fu6x7B09c0tXekaqmk/eBSj7RdtGgRr776KvXqFZ60uFGjRhftNIuIiIhjSM3K5dO/bov6T6+GRRdswTYtQk4a1GkJTa+ruIAiJRQaGnrBx9/Kq2Cbk5PDpk2b6Nu3b6H9ffv2Zc2aNUUes3bt2vPa9+vXj40bN5KbmwvYCrBubm6F2ri7u7Nq1apis0yePBlfX9+CR0hIyKW8JbmAjUfPsCcxDTcXMzdH6/MVEZHKxcls4sn+TQD4ZPURYk9l2jmRXEipi7YZGRl4eJw/2X5ycjIWi1aSFhERqQw+X3uUtKw8GtX2om+zwKIbpZ2Ade/btntNAPMlT4UvUmUlJyeTn59PYGDhf0eBgYEkJiYWeUxiYmKR7fPy8khOTgZsRdypU6eyf/9+rFYrixcv5ocffiiYmqwo48aNIyUlpeARFxd3me9O/u3TNUcAGNQ6GF8Pze8tIiKVT8/GtejaMICcfCuTf9198QPEbkr901f37t357LPPCp6bTCasVitTpkyhV69eZRpOREREyt65nHw+WnUYgFG9GmA2FzPKdtWbkHcOgttB434VmFCk8vn3aHXDMIofwV5M+3/uf+utt2jUqBFNmjTB1dWVhx56iDvvvBMnp+JXerZYLPj4+BR6SNlJSs1i4Q5bIV4LkImISGVlMpmYMKApZhP8uiORPw+dsnckKUapi7ZTpkzh/fffp3///uTk5PDEE0/QokULVq5cyauvvloeGUVERKQMfb0hllMZOYT4uTMwKqjoRinHYOOHtu3eE+ACxScRR7d582ZycspnsY2AgACcnJzOG1WblJR03mjav9WpU6fI9s7Ozvj7+wNQq1Ytvv/+ezIyMjh69Ch79uzBy8uL8PDwcnkfcnFfrY8jz2oQHVqT5kG+9o4jIiJyyZrU8WFYh/oAvPDzLvKtpVruSipIqYu2zZo1Y9u2bXTo0IE+ffqQkZHBjTfeyJYtW2jQoEF5ZBQREZEykpNnZdbKQwA80KMBzk7FdAVWvg75ORDaBSJ6VlxAkXLQvn17jhw5Ui7ndnV1JTo6msWLFxfav3jxYjp37lzkMZ06dTqv/aJFi2jXrh0uLoVvuXdzcyM4OJi8vDzmzZvH9ddfX7ZvQEokL9/K1xtiARhxhUbZiohI5Te2T2O8Lc7sPJ7KvM3H7B1HiuB8KQfVqVOHSZMmlXUWERERKWfztxwjISWL2t4WBkfXK7rR6cOw5XPbtkbZShXw99QD5WXs2LGMGDGCdu3a0alTJ2bNmkVsbCwPPPAAYJtrNj4+vmCKsQceeIDp06czduxY7r33XtauXcuHH37IV199VXDOdevWER8fT+vWrYmPj2fixIlYrVaeeOKJcn0vUrTle0+SkJJFTQ8X+resY+84IiIil83fy8IjVzbipQW7mfLbXq5pWRcvyyWVCaWclPqrsW3btiL3m0wm3NzcqF+/vhYkExERcUB5+VbeW34QgPu6R2BxLmZuzOWvgDUPGlwJoUWPFBSR/zdkyBBOnTrF888/T0JCAi1atGDBggWEhtpGZCYkJBAbG1vQPjw8nAULFjBmzBjeffddgoKCePvtt7npppsK2mRlZTFhwgQOHTqEl5cX11xzDZ9//jk1atSo6LcnwOz1tq/f4Oh6xX/vFBERqWRu7xzGl+uOcuRUJu8tP8Dj/ZrYO5L8g8ko5dADs9lcsEDCvxdMAHBxcWHIkCG8//77uLm5lWHUS5Oamoqvry8pKSlajEFERKq1H7ce55GvtlDTw4XVT/XGw7WI390m7YEZVwAG3LsMgttWeE6pHiqyj2Y2m9mzZw+NGzcu1+s4GvWDy0b82XN0e3UpVgOWPtaDiFpe9o4kIiJSZhbtTOS+zzfh6mzm97E9CPHzsHekKq+kfbRSz2k7f/58GjVqxKxZs9i6dSsxMTHMmjWLyMhIZs+ezYcffsjSpUuZMGHCZb0BERERKTtWq8GMZQcAuKtLeNEFW4DlLwMGNBmggq2ICDBnfSxWAzpF+KtgKyIiVU6fZoF0buBPTp6VVxbusXcc+YdST4/w0ksv8dZbb9GvX7+CfVFRUdSrV49nnnmG9evX4+npyWOPPcbrr79epmFFRETk0izefYI9iWl4W5wZ2Sms6EYJW2HXD4DJNpetiEg1l5dvZc7GOACGd6xv5zQiIiJlz2Qy8cyAZlz79h/8si2B2zudpkO4n71jCZcw0nb79u0F83P9U2hoKNu3bwegdevWJCQkXH46ERERuWyGYfDO0v2Abd4qXw+Xohsufcn2Z8uboXbTCkonIuK4lu5J4kRqNn6ervRtHmjvOCIiIuWiaV0fhrS3/XJy4o87ybeW7yKuUjKlLto2adKEV155hZycnIJ9ubm5vPLKKzRpYpuwOD4+nsBAdWpEREQcwfJ9J9kRn4qHqxN3dQ0vulHcetj/G5icoOdTFRtQRMRB/b0A2c1agExERKq4//ZtjI+bM7sSUvly3VF7xxEuYXqEd999l+uuu4569eoRFRWFyWRi27Zt5Ofn8/PPPwNw6NAhRo0aVeZhRUREpHQMw+Cd322jbG+7IhQ/T9eiG/7+vO3PNreCf4MKSidSMZ577jkCAgLsHUMqmbjTmazYdxKAYR00NYKIiFRt/l4WHu8XyTM/7GTKb3u5pmVdArws9o5VrZW6aNu5c2eOHDnCF198wb59+zAMg8GDBzN8+HC8vb0BGDFiRJkHFRERkdJbc/AUm2PPYnE2c0+3YkbZHloBR/4AJ1fo/kTFBhSpAM8995y9I0glNGdDHIYBXRr6Exbgae84IiIi5W54x1C+3hDHzuOpvPLrHl6/uZW9I1VrpS7aAnh5efHAAw+UdRYREREpY3/PZTusQ31qe7ud38AwYOkLtu12d0GNkApMJyLimHL/uQBZh/PX8xAREamKnMwmXhjUghtnrGHupmMM6xBCdKgWJbOXSyraAuzatYvY2NhCc9sCXHfddZcdSkRERC7fhiOn+fPQaVycTNzXPaLoRvsWwrEN4OIBXcdWbEAREQf1++4TnEzLJsDLlT7NtFaHiIhUH23r12RIuxDmbIzjme938uNDXXB2KvWSWFIGSl20PXToEDfccAPbt2/HZDJhGLYV5UwmEwD5+fllm1BEREQuydt/zWU7ODqEoBru5zewWuH3v0bZdrwfvFWYEBEBmL3eNsr25nYhuDrrB1UREalenrg6kl93JPy1KFkst3cOs3ekaqnUPZBHH32U8PBwTpw4gYeHBzt37mTlypW0a9eO5cuXl0NEERERKa2YuLP8sT8ZJ7OJB3sUs7DYjnmQtBMsvtDl0YoNKGIncXFx3HXXXfaOIQ4s7nQmf+z/awGy9lqATEREqh9/LwuPX90EgNcX7SU5PdvOiaqnUhdt165dy/PPP0+tWrUwm82YzWa6du3K5MmTeeSRR8ojo4iIiJTS9L/msh3UOpj6/h7nN8jPhWUv2ba7PALuNSswnYj9nD59mk8//dTeMcSBfbPRtgBZ14YBRX//FBERqQaGd6hPi2Af0rLyeOXXPfaOUy2VenqE/Px8vLy8AAgICOD48eNERkYSGhrK3r17yzygiIiIlM7O4yks2Z2EyQSjehUzynbL53DmMHjWgiserNiAIuXoxx9/vODrhw4dqqAkUhnlWw3mbjoGwJD2WphRRESqLyezieev//9FyYa0D6F9mBYlq0ilLtq2aNGCbdu2ERERQceOHXnttddwdXVl1qxZREQUs8iJiIiIVJh3fj8AwLUt69Kgltf5DXLPwYrXbNvdHwdXzwpMJ1K+Bg0aVGjdhaL8vRaDyL/9sf8kCSlZ1PBwoW9zzfMtIiLVW9v6NRnaPoSvN8Tx1LxtLHi0GxZnJ3vHqjZKPT3ChAkTsFqtALz44oscPXqUbt26sWDBAt5+++0yDygiIiIltzshlYU7EzGZ4JErGxXdaP0HkJYAvvUh+o4KzSdS3urWrcu8efOwWq1FPjZv3mzviOLAvt1oG2U7qHWwfigVEREBxvVvSoCXhYMnM3hv+UF7x6lWSl207devHzfeeCMAERER7Nq1i+TkZJKSkujdu3eZBxQREZGSe/t321y217SsS+NA7/MbZKXAqqm27Z5PgbOlAtOJlL/o6OgLFmYvNgpXqq/TGTks2pUIwC3tNDWCiIgIgK+HC88NbAbAjGUHOZCUZudE1Uepi7ZF8fPz021mIiIidrYnMZVfd/w1yrZ3MaNs174L585AQCS0GlqxAUUqwOOPP07nzp2Lfb1hw4YsW7asAhNJZTF/Szy5+QYtgn1oFuRj7zgiIiIOY0BUXXo3qU1OvpVx323HatUvwCtCmRRtRURExP4KRtm2qEtknSJG2WYk24q2AL3Hg1m3/krV061bN66++upiX/f09KRHjx4VmEgqA8Mw+HZjHPxfe3ceHlV593/8PZOVsATCvgQERfZFA+4balG0Uqu1ai3qU7Wl7vJYq1Xro31a2l/VUp+6r7Vu2FprtahQ674hCLJvsgSBAGFJ2LLNnN8fQ4KRTSHJmSTv13XNxck59xw+k9zX5OQ793wHONdVtpIkVROJRPjVmf3JSk/hk6UbePaT/LAjNQoWbSVJagDmFRQzYWbibb277WX77l1Qthk6DoY+I+sunCQluRlfFDGvYBMZqVFGDu4cdhxJkpJO55ZNuH54LwB+O2Eeq4tLQk7U8Fm0lSSpAfi/NxYBcNqADrteZbsxHz55JLF90i/BtkaSVGX89lW2p/bvQHaTtJDTSJKUnC466gAG5bZkU2kF//PP2WHHafAs2kqSVM/NL9jEv2auAvawyvbN30CsDLofBwf6waGSVGlbWYyXp68EbI0gSdKepEQj/PasAaRGI7w6q4CJswvCjtSgWbSVJKmeu+c/iV62I/p3oHeHXXx4zurZ8Nlzie2T/8dVtpL0Ja/OWsWm0gpyc5pwRI/WYceRJCmp9enYgsuO6wHArS/NomhreciJGi6LtpIk1WMLVm9iwt5W2b5xBxBA3+9A57y6CydJ9cDz21sjnJOXSzTqi1qSJO3NNSf1pEebpqwuLuX2V2yTUFss2kqSVI/d88ZCgiCxyrZPx12ssl32ASx4DSIpcOIv6z6gJCWxZeu28NHi9UQi8L28LmHHkSSpXshMS+H35wwiGoG/f7qCSXNWhx2pQbJoK0lSPbVg9V562QYBTLotsX3ohdDmoDpMJ0nJr3KV7bE929KpZZOQ00iSVH/kdWtV1Sbhpr/PZMOWspATNTwWbSVJqqf+MGkBQQCn9tvNKtv5E+CLyZDaBI7/ed0HlKQkFosHvDB1BeAHkEmStC+uO/lgerZrRuHmUm59aVbYcRoci7aSJNVDs1YU8eqsAiIRGDP84J0HxCq297IFjvgptOhYtwElKcm9v6iQguISspukcXLfdmHHkSSp3slMS+Hu7w8mJRrhlRmr+NeMVWFHalAs2kqSVA/9YdICAEYO6sTB7ZvvPOCzZ2HtPMhsCUdfU7fhJKkeeOHTL4DE82hGakrIaSRJqp8GdMnmihMOBOCWf8xk7abSkBM1HBZtJUmqZz7N38Ab89YQjSQ+uXUn5dvgrbGJ7WP/G5q0rNN8kpTsNpWU8/rsAgDO9gPIJEnaL1ee2JO+HVuwYWs5N784kyAIwo7UIFi0lSSpnqlcZXvWoV3o0bbZzgMmPwTFK6BFFzjsx3WcTpKS36szCygpj9OjbVMGdckOO44kSfVaemqUu74/iLSUCBPnrObFaSvCjtQgWLSVJKke+XjxOt5dWEhqNLLrVbZb18M7dyW2h/0C0jLrNqAk1QN/294a4exDuxCJREJOI0lS/denY4uqv09++dJs8tdtDTlR/WfRVpKkeiIIAu6amFhl+/2hueTmZO086J3fQ2kRtO8Pg86r44SSlPyWr9/K5CXriUTgrEM7hx1HkqQGY/TxBzL0gFZsLq3g6uemUR6Lhx2pXrNoK0lSPfHeokImL11PemqUq048aOcB6xfD5IcT29+6A6J+sI4kfdXfP028ZfPoA9vQMbtJyGkkSWo4UlOi/OHcwTTPTGX68o388d8Lw45Ur1m0lSSpHvjyKtsfHNZ114WGN+6AeDkceCIcdFIdJ5Sk5BcEAX+ftr01Qp6rbCVJqmldWmXx27MGAnDvW4v48PN1ISeqvyzaSpJUD/xn3hqmL99IZlqUy4cduPOAL6bA7BeBCHzrV3WeT5LqgynLNrBs3VaapqdwSr8OYceRJKlBOn1gR84dkksQwHXjp7Nxa1nYkeoli7aSJCW5eHzHKtuLjjyAds2/8uFiQQATb0lsD/4BdOhfxwklqX54YWpile2IAR3JSk8NOY0kSQ3XbSP70qNNUwqKS/j5CzMIgiDsSPWORVtJkpLcyzNWMmdVMc0yUvnJ8btYZTvvX5D/IaQ2gWE3131ASaoHSspj/GvGKgDOPrRLyGkkSWrYstJTuef8Q0hLifD67NU8O3l52JHqHYu2kiQlsbKKeNUq258c14OcpunVB8TK4d+3JbaPvByy7dEoSbsycc5qNpVW0LllEw7vnhN2HEmSGrz+nbO54ZTeANzxymzmF2wKOVH9YtFWkqQkNv6TfPLXb6VNswx+dEz3nQdMfQLWLYKsNnD0tXUdT5LqjcrWCGcf2ploNBJyGkmSGodLjunOcQe3paQ8zk+fmsqmkvKwI9UbFm0lSUpSW0or+OMbiwC4+qSDaJrxlf6LJcXw1m8T2yfcCJkt6jihJNUPq4tLeHfhWgC+a2sESZLqTDQa4Q/fH0TH7EwWF26xv+03YNFWkqQk9dh7SyjcXErXnCzOG9p15wHv3gVbC6H1QZB3cZ3nk6T64qXpK4gHkNetFd3bNA07jiRJjUrrZhnce8GhpKVEmDCzgEffWxJ2pHqhXhVtx44dSyQS4dprrw07iiRJtWr9ljIeemcxAP89/GDSU7/yK3v9EvjovsT2Kb+BlLQ6TihJ9cffP10BwFmH2vdbkqQwHNq1Fbd+uy8AY1+dx+Ql60NOlPzqTdH2k08+4aGHHmLgwIFhR5Ekqdbd9+YiNpVW0LdjC84Y2GnnAZNuhVgZ9BgGPYfXfUBJqifmF2xiXsEm0lIinD6gY9hxJElqtEYd0Y3vDO5ELB5w5TOfsmZTSdiRklq9KNpu3ryZCy64gIcffphWrVrtcWxpaSnFxcXVbpIk1ScrNm7jyQ+XAXDDqb12/sCcJe/C3JchEk2sso34gTqStDv/mJ5YZTusVztaZqWHnEaSpMYrEokw9qwB9GzXjDWbSrn62WlUxOJhx0pa9aJoe8UVV3D66adz8skn73Xs2LFjyc7Orrrl5ubWQUJJkmrOuEkLKIvFOaJHDscf3Lb6wXgMXr8psZ33X9C+b90HlKR6Ih4PeGlaomh75iG2RpAkKWxZ6anc/8M8mqan8NHi9fx+4vywIyWtpC/aPvfcc3z66aeMHTv2a42/6aabKCoqqrotX768lhNKklRzFq7exAuffgHADaf2JvLVVbTTn4aCmZCRDcN+EUJCSao/Plm6npVFJTTPSOXE3u3CjiNJkoCD2jXj/31vEAAPvr2Yl7a/K0bVpYYdYE+WL1/ONddcw8SJE8nMzPxa98nIyCAjI6OWk0mSVDvGvjqPeACn9GvPoV2/0hKopBje+FVi+/gboGmbug8oSfVIZWuEEQM6kJmWEnIaSZJU6fSBHZm54kAeePtzfva3GXTNyeKQr/7908gl9UrbqVOnsmbNGvLy8khNTSU1NZW3336be+65h9TUVGKxWNgRJUmqMe8vKuQ/89aQGo3w81N77zzgvbthyxrI6QGH/bjuA0pSPVJaEeNfM1YBcOZgWyNIkpRsfnZKL07u046yijg//stUVhVtCztSUknqou1JJ53EzJkzmT59etVtyJAhXHDBBUyfPp2UFF8tlyQ1DLF4wP/+ay4APzyiGz3aNqs+YMNS+PDexPbwX0OqH6YjSXvy1vy1FJdU0KFFJof3aB12HEmS9BUp0QjjzjuE3h2as3ZTKZc9OYWtZRVhx0oaSV20bd68Of379692a9q0Ka1bt6Z///5hx5Mkqca88OkXzF1VTPPMVK4+qefOAybeCrEy6H489BpR9wElqZ75x/YPIBs5uBMp0cheRkuSpDA0y0jl4QuHkNM0nVkrirn+r58Rjwdhx0oKSV20lSSpMdhaVsFd2z819aoTDyKn6VdW0X7+Jsz9J0SicMpv4KsfTiZJqqZoWzlvzFsDwHcGdwo5jSRJ2pPcnCweHJVHWkqECTML+OMbC8OOlBSS+oPIduWtt94KO4IkSTXq4XeWsLq4lNycJlx01AHVD1aUwas3JLaHXgYdfKeJJO3Na7NWUVYR5+D2zejbsUXYcSRJ0l4MPSCHX393ADf8bQZ/fGMhB7ZrxshBjfuFV1faSpIUojXFJTz4zucA/PzU3mSkfqVf+8cPQOECyGoDw34RQkJJqn/+MW0lAN8Z3JmI706QJKle+P6QXC47tjsA1z//GR98XhhyonBZtJUkKUR3TVzA1rIYh3ZtyekDOlY/WLwK3v5dYvtbt0OTlnWeT5Lqm1VF2/hoyTrA1giSJNU3N47ow2kDOlAWi/OTJ6cyd1Vx2JFCY9FWkqSQzF1VzPNTlwNw8+l9d14NNumXULYZOg+BQT8IIaEk1T//nL6SIIDDDsihS6ussONIkqRvICUa4e7vD+aw7jlsKq3g4scns2LjtrBjhcKirSRJIQiCgN9MmEsQwOkDO5LXrVX1AUvfh5nPAxE47fcQ9Ve2JH0d/5i+vTXCIa6ylSSpPspMS+HhUUM4uH0zVheXcuGjH7NhS1nYseqcfwFKkhSCN+au4d2FhaSnRLnx1N7VD8YqYMLPEtt5F0PnQ+s8nyTVR/MLNjF3VTFpKZGdW85IkqR6IzsrjT//6DA6Zmfy+dotXPrkFErKY2HHqlMWbSVJqmMl5THueGUOAJcc253cnK+8fXfKo7BmNjRpBSf9MoSEklQ/vfxZYpXt8Qe3o2VWeshpJEnS/uiY3YQ//+gwWmSmMnXZBq56dhoVsXjYseqMRVtJkurYI+8uJn/9Vtq3yODKYQdVP7h5Lfzn14ntE2+FrJy6DyjpG7vvvvvo3r07mZmZ5OXl8e677+5x/Ntvv01eXh6ZmZn06NGDBx54YKcx48aNo1evXjRp0oTc3Fyuu+46SkpKaush1HtBEPDP7UXbkX4AmSRJDcLB7Zvz6MVDSU+NMmnOam742wzi8SDsWHXCoq0kSXVo5cZt3Pvm5wD84rQ+NM1IrT5g0q1QWgQdByVaI0hKeuPHj+faa6/l5ptvZtq0aRx77LGMGDGC/Pz8XY5fsmQJp512GsceeyzTpk3jF7/4BVdffTUvvPBC1Zinn36aG2+8kdtuu425c+fy6KOPMn78eG666aa6elj1zowvishfv5UmaSmc3Kdd2HEkSVINGXpADn86/xBSoxH+Pm0Fv3hxZqMo3Fq0lSSpDv1mwly2lcc47IAcRg76ykqwxW/DZ88CETj9boimhJJR0jdz9913c8kll3DppZfSp08fxo0bR25uLvfff/8uxz/wwAN07dqVcePG0adPHy699FJ+9KMfceedd1aN+fDDDzn66KP5wQ9+wAEHHMDw4cM5//zzmTJlym5zlJaWUlxcXO3WmFSusj25b3uy0lP3MlqSJNUnw/t1YNx5g4lG4LlPlnP7y7MJgoZduLVoK0lSHfnw83W8MmMV0QjcNrIvkUhkx8HyEnjlusT20Euhy5BwQkr6RsrKypg6dSrDhw+vtn/48OF88MEHu7zPhx9+uNP4U045hSlTplBeXg7AMcccw9SpU5k8eTIAixcvZsKECZx++um7zTJ27Fiys7Orbrm5ufvz0OqVeDzglRnbWyN89QUxSZLUIHx7YCfuPGcQkQj8+cNljH11XoMu3Fq0lSSpDlTE4tz+8mwAfnB4V/p1yq4+4L0/wPrPoVkHOOnWEBJK2heFhYXEYjHat29fbX/79u0pKCjY5X0KCgp2Ob6iooLCwkIAzjvvPH71q19xzDHHkJaWxoEHHsiwYcO48cYbd5vlpptuoqioqOq2fPny/Xx09cfkpetZXVxK88xUjju4TdhxJElSLTnr0C785rsDAHjoncX8YdKCkBPVHt83JElSHXjqo2XMK9hEy6w0/vtbvaofXLsA3rs7sT3it5CZvfMJJCW1aivnSXwo1lf37W38l/e/9dZb/PrXv+a+++7j8MMPZ9GiRVxzzTV07NiRW2/d9Qs7GRkZZGRk7M/DqLde3t4a4dR+HchItbWMJEkN2fmHdaWsIs5t/5zNPf9ZRFpKlKtO6hl2rBpn0VaSpFq2bnMpd29/Bfj64b1o1TR9x8EgSLRFiJVBz+HQ98xwQkraJ23atCElJWWnVbVr1qzZaTVtpQ4dOuxyfGpqKq1btwbg1ltvZdSoUVx66aUADBgwgC1btvDjH/+Ym2++mWjUN8xVKo/FeXVW4vs5crCtESRJagwuOuoASiti/GbCPO6atICyWJwx3zp4jy+a1zde7UmSVMt+//p8iksq6NuxBecf1rX6wenPwLL3ILUJnHYnNKCLDKkxSE9PJy8vj0mTJlXbP2nSJI466qhd3ufII4/cafzEiRMZMmQIaWlpAGzdunWnwmxKSgpBEDTo3m374v1FhazfUkabZukc2aN12HEkSVId+fFxB3LjiN4A/N9/FvGrV+Y2qOski7aSJNWiKUvX89wnib6St3+nHynRLxVlt6yDibcktofdBK26hZBQ0v4aM2YMjzzyCI899hhz587luuuuIz8/n9GjRwOJXrMXXnhh1fjRo0ezbNkyxowZw9y5c3nsscd49NFHuf7666vGnHHGGdx///0899xzLFmyhEmTJnHrrbcycuRIUlJ8+/+XvfzZKgBOG9CR1BT/vJEkqTEZffyB3PGdfgA89v4SfvHiTGLxhlG4tT2CJEm1pKwizi9enAnAuUNyGXpATvUBk26FbeuhfX844vIQEkqqCeeeey7r1q3jjjvuYNWqVfTv358JEybQrVvihZhVq1aRn59fNb579+5MmDCB6667jnvvvZdOnTpxzz33cPbZZ1eNueWWW4hEItxyyy2sWLGCtm3bcsYZZ/DrX/+6zh9fMispjzFxdqI1whmDbI0gSVJjdOGRB9AkLYWfvzCDZycvZ2tZjLvOGVTvX8yNBA1p3fAuFBcXk52dTVFRES1atAg7jiSpEbn3zUX8/vX55DRN540xx1fvZfv5m/CXM4EIXDIJcoeGFVMKhddota8xfI9fm1XA6Kem0ik7k/d+fiLRqC1mJElqrF6ZsZJrn5tORTxgeN/2/N8PDknKDyj9utdo9bvkLElSklq2bgv3vLEQgFtO71O9YFu6Cf55dWL7sMss2ErSPnr5s5UAfHtQJwu2kiQ1ct8e2IkHR+WRnhpl4pzV/Nfjn1BcUh52rH1m0VaSpBoWBAG3/GMWpRVxjjqwNd89pHP1Af/+HyjKh5bd4KTbQskoSfXd5tIK3pi3GoCRtkaQJEnASX3a8/jFQ2mansIHn6/jnPs/ZOXGbWHH2icWbSVJqmEvz1jFuwsLSU+N8r9n9icS+dLqryXvwiePJLZH/h9kNAsnpCTVc2/MXU1JeZzubZrSr1PDbP8gSZK+uaMPasP4nxxJ2+YZzF+9ibPu+4C5q4rDjvWNWbSVJKkGFW0t546X5wBw5bCD6NH2S0XZsi3wzysT23n/BT2ODyGhJDUM/5yeaI1wxsCO1V8ckyRJjV7/ztm8ePlRHNSuGQXFJZzzwIe8t7Aw7FjfiEVbSZJq0O9en0fh5lIObNuUnxzfo/rBN34FG5ZCiy7wrTtCySdJDUHR1nLeWbgWgDNsjSBJknahS6ssXhh9FId3z2FzaQUXPz6Zv039IuxYX5tFW0mSasiUpet55uN8AH7z3QHVP6k0/yP4+IHE9sg/QqZv5ZWkfTVxTgHlsYDeHZrTs33zsONIkqQklZ2VxpOXHMbIQZ2oiAdc/9fP+N1r84jFg7Cj7ZVFW0mSakBJeYwb/jYDgHPyunB4j9Y7DpZvg5euAAIY/EM46ORwQkpSA/GvmasAOG1Ax5CTSJKkZJeRmsK4cwdz+QkHAnD/W59zyZ8/oWhbecjJ9syirSRJNeDO1+ezuHAL7VtkcMvpfasf/M//wrpF0LwjnPLrcAJKUgOxcWtZVU86i7aSJOnriEYj3HBqb/543mAy06K8NX8tZ977PovWbAo72m5ZtJUkaT9NWbqeR99fAsDYswaQnZW24+CSd+HDexPb3x4HTVrWeT5Jakgmzl5NRTzRGuGgds32fgdJkqTtvjO4M38bfRSdWzZhSeEWzrz3AybNWR12rF2yaCtJ0n7YVhbjZ3+bQRDA2Yd24cTe7b90cCO8OBoI4NALodepYcWUpAajsjXCtwe6ylaSJH1z/Ttn888rj676gLLLnpzCH/+9kHiS9bm1aCtJ0n64c+J8lmxvi/DLM77SFmHCz6D4C2jVHU4ZG05ASWpANmwp4/1FtkaQJEn7p3WzDJ669HAuOrIbAH96cyGfr90ccqrqUsMOIElSffXJ0vU8tr0twm/PGkh2ky+1RZj5N5j5PERS4KyHIcO38ErS/po4p4CKeEDfji3o0dbnVUmStO/SUqLc/p3+9OuUDUDP9s1DTlSdRVtJkvbBtrIYP/vrZwQBfC+vC8N6t9txsOgL+NeYxPZxP4PcoeGElKQG5pUZidYIp9saQZIk1ZDvD80NO8Iu2R5BkqR9cOfE+Sxdt5UOLTK59dtfaosQjyf62JYUQechcNz14YWUpAZk/ZYyPvh8HQCn2xpBkiQ1cBZtJUn6hj78fF1VW4SxZw+o3hbho3th6buQlgVnPQQpabs5iyTpm3h9dgGxeED/zi04oE3TsONIkiTVKou2kiR9Axu3lnHd+OkEAZw3NJdhvb7UFqFgFrxxR2L71LHQ+sBwQkpSA/Sv7a0R/AAySZLUGFi0lSTpawqCgBtfmElBcQk92jTll2d8qS1C6Sb460UQK4Nep8GhF4UXVJIamHWbS/ng80LA1giSJKlxsGgrSdLX9Nwny3ltdgFpKRHuOf8QstK3f55nEMAr18G6RdCiM4z8E0Qi4YaVpAbk9dmriQcwoHM23VrbGkGSJDV8Fm0lSfoaFq3ZzO0vzwbgZ6f0on/n7B0HP/0zzPwrRFLge49B09YhpZSkhulfM1cCcPpAV9lKkqTGwaKtJEl7UVoR45rnplFSHueYg9pw6TE9dhwsmAkTbkhsn/RL6HpEOCElqYEq3FzKh5+vA2yNIEmSGg+LtpIk7cWdr89n9spicpqmc/f3BxGNbm99ULoJ/noxxEqh53A46upQc0pSQ/TarALiAQzqkk1uTlbYcSRJkuqERVtJkvbgnQVrefjdJQD87uyBtGuRmTgQBPDytTv62H73QYj6a1WSatqEmasAOM1VtpIkqRHxr0tJknajoKiEMc9PB2DUEd34Vt/2Ow5OfQJm/W17H9vHISsnlIyS1JCt21zKx0vWAxZtJUlS42LRVpKkXSiriHPFM59SuLmM3h2ac/PpfXYcXPEpvPrzxPbJt0HXw8MJKUkN3KQ5q4nFA/p3bmFrBEmS1KhYtJUkaRfGvjqXqcs20DwzlQdH5ZGZlpI4sHkNjP9hoo/twSPgyKvCDSpJDdiEWQUAjOjvKltJktS4WLSVJOkr/vnZSh5/fykAd39/MN1aN00cqCiD8aOgeAW07gln2cdWkmpL0dZyPlhUCMCI/h1CTiNJklS3/EtTkqQvWbh6Eze+MAOAy084sHof21d/Bss/gowWcP6zkJkdUkpJavgmzV1NRTygd4fm9GjbLOw4kiRJdcqirSRJ220ureAnT01la1mMow9qzX8P77Xj4CePJj58jAic/Si06RlWTElqFF6duQqAU11lK0mSGiGLtpIkAUEQcMPfPmPx2i10zM7knvMOISUaSRxc9gG8ekNi+6RfwsHDwwsqSY3AppJy3l2YaI1w2gD72UqSpMbHoq0kScCD7yxmwswC0lIi3HvBobRulpE4UPQFPH8hxCug31lwzHXhBpWkRuA/89ZQFotzYNum9GxnawRJktT4WLSVJDV6r88u4HevzQPgl9/uy6FdWyUOlG6CZ8+HLWuh/QD4zp8gEgkxqSQ1DhO2t0YY0b8jEZ93JUlSI5TURduxY8cydOhQmjdvTrt27TjzzDOZP39+2LEkSQ3IrBVFXPvcdIIALjyyG6OOPCBxIFYBf70YCmZAVhs472lIbxpmVElqFLaUVvDW/LUAjBhgP1tJktQ4JXXR9u233+aKK67go48+YtKkSVRUVDB8+HC2bNkSdjRJUgOwuriES/88hW3lMY7t2YZffrtv4kAQwL+ug0X/htQm8IPnoVW3cMNKUiPx1vy1lFbE6dY6i74dW4QdR5IkKRSpYQfYk9dee63a148//jjt2rVj6tSpHHfccbu8T2lpKaWlpVVfFxcX12pGSVL9tK0sxqV/nkJBcQk92zXj3gsOJTVl+2uZ794Fnz4JkSh87zHokhduWElqRCbMSrRGOLV/B1sjSJKkRiupV9p+VVFREQA5OTm7HTN27Fiys7Orbrm5uXUVT5JUT8TjAWOen87MFUXkNE3n0YuG0iIzLXHws/Hwn18ltkf8P+h9WnhBJamRKSmP8ea8NQCc1r9jyGkkSZLCU2+KtkEQMGbMGI455hj69++/23E33XQTRUVFVbfly5fXYUpJUn1w16T5vDqrgPSUKA+OyqNr66zEgcVvw0tXJLaPuhoOuyy8kJLUCL29YC1by2J0btmEgV2yw44jSZIUmqRuj/BlV155JTNmzOC9997b47iMjAwyMjLqKJUkqb75y0fLuPfNzwH47dkDGHrA9ndvrJ4N40dBvBz6fRdOvj3ElJLUOL0609YIkiRJUE+KtldddRX//Oc/eeedd+jSpUvYcSRJ9dTLn63kly/NAuDqk3py1qHbf6es+xyePBNKi6DrUXDmAxCtN29GkaQGobQixhtzt7dGGNAh5DSSJEnhSuqibRAEXHXVVbz44ou89dZbdO/ePexIkqR66u0Faxnz/HSCAEYd0Y3rTu6ZOLAxH/48ErasgfYD4PxnIC0z3LCS1Ai9v6iQTaUVtGuewSG5rcKOI0mSFKqkLtpeccUVPPPMM7z00ks0b96cgoICALKzs2nSpEnI6SRJ9cWn+RsY/ZeplMcCzhjUidtH9ku87bZ4VaJgW/wFtDkYRr0ITSwUSFIYXp+1Gki0RohGbY0gSZIat6R+7+f9999PUVERJ5xwAh07dqy6jR8/PuxokqR6Yn7BJv7r8U/YVh7juIPbctc5gxLFgC2F8JczYcMSaNkNLnwJmrUNO64kNUoVsTiT5m4v2vazNYIkSVJSr7QNgiDsCJKkemz5+q2MevRjiraVc0jXljzww0NJT43Cto3wl+/C2nnQvBNc9E9o0SnsuJLUaH2ydAPrt5TRMiuNw7rnhB1HkiQpdEm90laSpH31xYatXPDIx6zZVMrB7Zvx+MVDyUpPhZJiePocKJgBTdsmCratDgg7riQ1aq/PTrRBO7lPe1JT/BNFkiQpqVfaSpK0L5av38r5D3/EFxu20TUniyd/dDgts9Jh63p46ixYOQ0yW8Kof0CbnmHHlaRGLQiCqqKtrREkSZISLNpKkhqU/HWJgu2Kjds4oHUWz/74CDpkZ8LmtYketqtnQZOcxIeOdegfdlxJavRmfFHEqqISstJTOKZnm7DjSJIkJQWLtpKkBmPZui2c/9BHrCwqoUebpjz74yNo3yITilfCn0fCuoXQrH1ihW37vmHHlSQBr21fZTusdzsy01JCTiNJkpQcLNpKkhqEJYWJgm1BcQkHtm3Ks5cdQbsWmbBhGTw5EjYshRZdEj1sWx8YdlxJEonWCK/NShRtT7E1giRJUhWLtpKkem/Rms1c8MhHrC4upWe7Zjxz2RG0bZ4BhYsSBdviFYkPG7voZWjZNey4kqTtFq7ZzJLCLaSnRBnWq23YcSRJkpKGRVtJUr02ddl6LvnzFDZuLadX++Y8fdnhtGmWAcs/gWfPha3roM3BcOFL0KJT2HElSV9Sucr2mJ5taJ6ZFnIaSZKk5GHRVpJUb02as5orn/mU0oo4g3Nb8tjFQ8lpmg5zX4YXLoWKEug4CC54AZq5gkuSks3r2/vZnmprBEmSpGos2kqS6qVnPs7nln/MJB7ASb3b8X8/OISs9FT48D54/RdAAD1Pge89BhnNwo4rSfqK5eu3MntlMdEInNSnXdhxJEmSkopFW0lSvRIEAX/490LueWMhAOcNzeV/z+xPaiSAV38OHz+QGDjkRzDi95DirzpJSkaVq2wP655D62YZIaeRJElKLv4lK0mqN8oq4tz6j1mMn7IcgGtO6sm1J/ckUr4N/n4ZzHslMfDk2+HoayASCTGtJGlPKvvZ2hpBkiRpZxZtJUn1QuHmUi5/6lMmL11PNAL/e+YAfnB4V1i/BMaPgtUzISUdvvsA9D877LiSpD1Ys6mEqfkbABhu0VaSJGknFm0lSUlv5hdF/OQvU1hZVELzjFT+eP5gTuzdHhZOghcugZIiaNoWvv8X6HZk2HElSXsxac5qggAG5bakU8smYceRJElKOhZtJUlJ7R/TVvDzF2ZQWhGnR9umPDRqCAe1yYK3fw9v/hoIoPMQ+P6TkN057LiSpK+hsjXCKf3ah5xEkiQpOVm0lSQlpYpYnN++Oo9H3lsCwEm92/GH8wbTgq0w/ocw/1+JgXkXw4j/B6l+iI0k1QdF28r58PN1AJxiawRJkqRdioYdQJKkr1pdXMKoRydXFWyvHHYQD184hBbrZ8NDwxIF25R0OOMeOOOPFmwlhe6+++6je/fuZGZmkpeXx7vvvrvH8W+//TZ5eXlkZmbSo0cPHnjggWrHTzjhBCKRyE63008/vTYfRp14a/4aKuIBPds148C2zcKOI0mSlJRcaStJSipvzF3N9X/9jA1by8lKT+HOcwZxWr/28MEf4T//C/FyaNEZzv0LdM4LO64kMX78eK699lruu+8+jj76aB588EFGjBjBnDlz6Nq1607jlyxZwmmnncZll13GU089xfvvv8/ll19O27ZtOfvsxAcp/v3vf6esrKzqPuvWrWPQoEGcc845dfa4asvrsxOtEYbbGkGSJGm3LNpKkpJCSXmM3746jyc+WApAv04t+L/zD6FHehE8ORKWbl+11vvbMPL/ICsnvLCS9CV33303l1xyCZdeeikA48aN4/XXX+f+++9n7NixO41/4IEH6Nq1K+PGjQOgT58+TJkyhTvvvLOqaJuTU/057rnnniMrK2uPRdvS0lJKS0urvi4uLt7fh1bjSspjvDV/LQDD+9oaQZIkaXdsjyBJCt2iNZs48973qwq2lx7Tnb9ffhQ91r4B9x+VKNimZSXaIZz7lAVbSUmjrKyMqVOnMnz48Gr7hw8fzgcffLDL+3z44Yc7jT/llFOYMmUK5eXlu7zPo48+ynnnnUfTpk13m2Xs2LFkZ2dX3XJzc7/ho6l9H3xeyNayGB1aZDKgc3bYcSRJkpKWK20lSaGJxwOe/HApv31tHiXlcVo3TefO7w9iWG4qvHwlfPZMYmDHwXD2o9DmoFDzStJXFRYWEovFaN+++lv927dvT0FBwS7vU1BQsMvxFRUVFBYW0rFjx2rHJk+ezKxZs3j00Uf3mOWmm25izJgxVV8XFxcnXeF24uzVQKI1QjQaCTmNJElS8rJoK0kKxaI1m/j5CzOZumwDAMf2bMNd5wykXf4EuPfnsGUtEIFjroUTfgGp6aHmlaQ9iUSqFyCDINhp397G72o/JFbZ9u/fn8MOO2yPGTIyMsjISN4PZozFA/49d3vR1tYIkiRJe2TRVpJUp8pjcR56ZzF//PdCymJxmmWkcuOI3vygV5ToKxfDgtcSA9v0SvSu7Xp4qHklaU/atGlDSkrKTqtq16xZs9Nq2kodOnTY5fjU1FRat25dbf/WrVt57rnnuOOOO2o2eAg+zd9A4eYymmemcngP29xIkiTtiT1tJUl1ZtaKIkb+6X1+//p8ymJxTujVlonXHM0PoxOJ3n9EomAbTYMTboLR71qwlZT00tPTycvLY9KkSdX2T5o0iaOOOmqX9znyyCN3Gj9x4kSGDBlCWlpatf3PP/88paWl/PCHP6zZ4CGYODtRqD6pdzvSUvwzRJIkaU9caStJqnXrt5Rx96T5PPNxPvEAWmalcdsZfTmz1VIiz4+AghmJgbmHJz5srF3vcANL0jcwZswYRo0axZAhQzjyyCN56KGHyM/PZ/To0UCi1+yKFSt48sknARg9ejR/+tOfGDNmDJdddhkffvghjz76KM8+++xO53700Uc588wzd1qBW98EQcDEOYnWCKf0szWCJEnS3li0lSTVmvJYnKc/WsbdkxZQXFIBwLcHduT245rR+oNfwJyXEgMzsuGkW2HIJRB19ZWk+uXcc89l3bp13HHHHaxatYr+/fszYcIEunXrBsCqVavIz8+vGt+9e3cmTJjAddddx7333kunTp245557OPvss6udd8GCBbz33ntMnDixTh9PbViwejPL1m0lPTXKcQe3DTuOJElS0osElZ960EAVFxeTnZ1NUVERLVq0CDuOJDUa7y0s5PaXZ7NwzWYAendozu2nduPwL56AD++FWClEopD3XzDsF9C0TbiBJdUpr9FqXzJ9j//vjYXcNWkBJ/Vux6MXDw01iyRJUpi+7jWaK20lSTVq9soi7p64gDfmrQGgVVYaPzvpAM6N/JuUly+BLYn9dD8eTh0L7fuFmFaSVBcqWyMM77frD2eTJElSdRZtJUk1YuHqTfzh3wuYMDPxQTMp0Qj/dXhH/rvNZJp8dDVsWpUY2Ko7nPJr6HUaRCIhJpYk1YUVG7cxc0UR0Qic3MeirSRJ0tdh0VaStF+WFm7hj28s5B/TVxAEiTrsdwa04+bO02j76Q0wbXliYIvOcNz1MPiHkJoebmhJUp2ZNDvxYt6Qbjm0bpYRchpJkqT6waKtJGmfzFlZzEPvfM7LM1YRiyfao4/s05xbOk6l3ewbYcH2D91p1gGO/W/IuwhS/WNdkhobWyNIkiR9cxZtJUlfWxAEvL9oHQ++8znvLiys2n/mgVF+0eYd2s1/GpYUJXZmtYFjroOhl0Bak5ASS5LCtHFrGR8vWQ/A8L4dQk4jSZJUf1i0lSTtVWlFjFdnFvDQO4uZs6oYgGgEfnLwZi7L+Dc5i16EFeWJwa0PgiOvhEHnWayVpEbuP/PWEIsH9O7QnK6ts8KOI0mSVG9YtJUk7dbSwi08Ozmfv079gvVbygDISSvnf7rP5dSSV0lf9tmOwV2PhKOugoNHQDQaUmJJUjKZOHt7a4S+tkaQJEn6JizaSpKqKY/FeWPuap7+OL9aC4Rjmq3ihrYfMWDda0TyNyV2RtOg70g4/KeQOzSkxJKkZFRSHuPtBWsBGN7P1giSJEnfhEVbSRJBEDBt+UZemraCV2asYt32VbWdI4Vc0/4zRgTv0rxoAazafoecHpB3MQy+AJq2CS23JCl5vb+okG3lMTplZ9KvU4uw40iSJNUrFm0lqRFbvHYz/5i+kpemr2DZuq0AZLOZS7M+5aKmH5O7aRps3D44JR16jYC8/4Lux9sCQZK0R5PmJFojnNy3PZFIJOQ0kiRJ9YtFW0lqRIIgYM6qYl6fvZqJswuYV5Boc9CRdVyWPpVzms2g57bPiMRjsL0DAt2OgYHnQN/vQJNW4YWXJNUb8XjAv+euAeBb9rOVJEn6xizaSlIDV1YRZ+qyDUyas5qJcwr4YsM2IsTpG8nnqtTpnJU1je5lCxODt26/U/v+MOB70P970DI3tOySpPpp2vKNFG4upXlGKod3bx12HEmSpHrHoq0kNUBLC7fw7sK1vL2gkA8/L2RLWYw2FHFsdAY3pM/khLRZtIhtTAwuA4hA1yOg9+mJW06PENNLkuq7ytYIJ/RuR3qq7XQkSZK+KYu2ktQArNy4jclL1vPxkvW8v6iQ/PVbyaGYodF5XB+dy1GZ8+nF0h13iAHpzeCAYxN9anuNgGbtwoovSWpgJs0pAGyNIEmStK8s2kpSPROLB3y+djPT8jfw8ZL1TF6ynhUbtnBAZDWDI4v4SXQBh2fM46DIip3v3GEgHHQSHHgS5B4Oqel1/wAkSQ3a4rWb+XztFtJSIpzQq23YcSRJkuoli7aSlMSCIKCguITPlhcxfflGPlu+kZkrNpJVWki/6FIGRxdxZmQRgzIWkx3ZsvMJ2vWFbkdDt6PggGNcTStJqnWVrRGO6NGaFplpIaeRJEmqnyzaSlKSKKuI8/nazcxZWczcVcXMWVXMwpXraFWynN6RfPpGl/HTyDL6RpfRJrN45xOkZkLHQdBlaKJI2/VIyMqp+wciSWrUKou2tkaQJEnadxZtJamObSopZ2nhVhat3cTC1ZtZtGYzK9esIWXDYroFK+kZXcGQyArOi6zggEgBqRnxnc4RRKJEWveEznnQJS/xb/v+kOKKJklSeAo3lzI1fwMAJ/exaCtJkrSvLNpKUg2LxwPWbi7liw1b+WLDNvLXbWVp4SaK135BfMMymm1bSW5kLd2jBZwYWc2PIgW0iRTDbuqtQXozIu36QseB0GEAdBiQ+DqtSd0+MEmS9uI/c9cQBNC/cws6tfT3lCRJ0r6yaCtJ30A8HrB+axkFRSWsLi5hVVEJa4o2s2ldAWUbVxIUrSR9awFtgnV0jKynA+sZGCmkc6SQ9EgscZLdfPZXLKst0TYHEWnbC9r2hra9oE0vIi06QSRSdw9SkqR9NLGyNUKfDiEnkSRJqt8s2kpq1IIgYEtZjA1bylhfedtcwuaiDWwtLqS8eA2xzWthayGp29aTWb6BVhTTlo10jBQxMLKRHIpJiQQ7Tpqy6/8rHkmholknoq26kZrTDXK6Q86BkNMDcnqQktmibh60JEm1YFtZjPcWrQXsZytJkrS/6kXR9r777uP3v/89q1atol+/fowbN45jjz027FiSQhYEAWWxOFtLY2wurWBzaQVbSsrZsnULpVuLKd1cROmWIiq2FVGxrZigpJigZBORsmJSyopJL99EesVmmrOF7MgWstlCl8hmstlCamTnPrLA7guyRCnNyCHWrCMpLTuTkZNLNLszNO8E2V2gZVeizTuSnlIvnnYlSfrG3l24lpLyOJ1bNqFPx+Zhx5EkSarXkr56MH78eK699lruu+8+jj76aB588EFGjBjBnDlz6Nq1a9jxJJEonpbHAiriccorEoXUsooKystKqSgrTfxbXkpFWQkVZdv/LS8lVl5CrLyUWFkJ8fLELSgvIagohfJtUFECFduIVpQSiZUSjZWQGishLbaNtKCE9HgpmZTShFKaRkroQilZlFRf9bo3uynCApRFMylNa0l5Zg5BVhuiTduQnt2OzOx2pDTvAM3aQ7N20LwD0azWNInu4WSSJDVwkypbI/RtT8S2PpIkSfsl6Yu2d999N5dccgmXXnopAOPGjeP111/n/vvvZ+zYsSGn29mS2R8Tj3+DgtHuBLtZ5berobs98E1y7HpssKtz7Oa8uxz7pXN/+fhux1bbv4vxuzvHl75fATuGRggIKvfEt28FAfDl7e1fxeNV25EAAuJVJ/ry/x9U3j/Y/r8FwZf2xxO7CLZn2r5/+/HKbYJ4tXMlvo4nMsVjO/bH40A88XU8vmNcsOM+ia/jRII4QTzxb2J/DII4kSCW2I4HX9q3Y3/l9o5bnGgQI7r9eDSIESXxb8r2r1OoIEqM1CBGKhWkEqu6ZVBBU2K7X6lak6J7PlwSaUJpShblKU2pSG1KLL05QXpTIpnZRJu0JLVpK9KbtaJJ8xzSsrKJZLWGrBxo0goyW5Kelrm79rOSJOlLYvGA/8xbA8BwWyNIkiTtt6Qu2paVlTF16lRuvPHGavuHDx/OBx98sMv7lJaWUlpaWvV1cXFxrWb8qvbPn0FWpHTvA6WG4BssookRpZxUKiJpVJBGRSSVWDSdWCSVimgG8Wg6sZQM4tEMgpR0gtRMSM2EtEwiqU2IpDchJa0J0YwsUjObkpbZjLQmTcnIbEZGVlNSM1tAelNIb5b4Ny2LzGiUzNp79JIkabtP8zewbksZLTJTGdo9J+w4kiRJ9V5SF20LCwuJxWK0b1/91fr27dtTUFCwy/uMHTuW22+/vS7i7dL6aCu2BLVXtA2+SZWsFs+9+7G73h/sYnf1c0S+tH93Ijvdb3c5gqq35O18n8qvq/ZFKsfs6v+JfOV8O/YHRLYfjlSdL0LlY43sGBeJVr9fZPt5I5VjolX3IRIlIJo4Fqn8f6KJ/VX3qzye2J+4fzTxNsRICkF0x36iUSKRKERSIJqy/d/t+6IpRKKpRKKp27dTIGX7vpRUUqIpkJJGNCWVSDSFlNQ0oilpRFNTt2+nk5qaRjQtjdS0dFJT0klNTyMlNYO09HQiKRmQkgYp6ZCSRko0ZU+dCCRJUj22cWs5XVo1YUi3VqSl7OWtMJIkSdqrpC7aVvpqT6wgCHbbJ+umm25izJgxVV8XFxeTm5tbq/m+rMtt8+vs/5IkSZKSwbf6tufkPu3YWhYLO4okSVKDkNRF2zZt2pCSkrLTqto1a9bstPq2UkZGBhkZGXURT5IkSdJ2kUiEphlJ/eeFJElSvZHU711KT08nLy+PSZMmVds/adIkjjrqqJBSSZIkSZIkSVLtSfqXwseMGcOoUaMYMmQIRx55JA899BD5+fmMHj067GiSJEmSJEmSVOOSvmh77rnnsm7dOu644w5WrVpF//79mTBhAt26dQs7miRJkiRJkiTVuKQv2gJcfvnlXH755WHHkCRJkiRJkqRal9Q9bSVJkiRJkiSpsbFoK0mSJEmSJElJxKKtJEmSJEmSJCURi7aSJEmSJEmSlEQs2kqSJEmSJElSErFoK0mSJEmSJElJxKKtJEmSJEmSJCURi7aSJEmSJEmSlEQs2kqSJEmSJElSErFoK0mSJEmSJElJJDXsALUtCAIAiouLQ04iSZKkSpXXZpXXaqp5XgdLkiQln697Hdzgi7abNm0CIDc3N+QkkiRJ+qpNmzaRnZ0ddowGyetgSZKk5LW36+BI0MCXN8TjcVauXEnz5s2JRCJV+4cOHconn3xSK/9nbZ57fxQXF5Obm8vy5ctp0aJFtWN7yry3x7O/x/d17L6Mr61zhHHu/bEvc6Emfs5f9/uxL9+3/f1eOw98TqjJc4Rx7v3hc0LN3z+sc++P2nhO2NOxIAjYtGkTnTp1Ihq1Y1dt8Dp4h7qe399kzDcZt7/3qcn7h3Xu/bW7ueC1T+OaCz4n1Pz9wzr3/vDvodo7Rxjn3h/Jeh3c4FfaRqNRunTpstP+lJSUnX4QNaU2z10TWrRosVO+PWXe2+PZ3+P7OnZfxtfWOcI4d034JnOhJn7OX/f7sS/ft/39XjsPfE6oyXOEce6a4HNCzd0/rHPXhJp8TtjbY3WFbe3yOnhndTm/v+6YbzJuf+9Tk/cP69w15atzwWufxjkXfE6oufuHde6a4N9DNX+OMM5dE5LtOrjRLmu44oor6uW5a8ueMu/t8ezv8X0duy/ja+scYZy7tuwuc038nL/u92Nfvm/7+712HlTnc0LtaEhzweeE5Dx3bdnX54T6+FgbA+d3dbU5v32eqz+89qkdjWku+JwQzrlri88JtaMxzYWaeKwNvj2CdiguLiY7O5uioqKkfmVDtc+5IHAeaAfngsB5oIbN+a1KzgWB80AJzgNVSta50GhX2jZGGRkZ3HbbbWRkZIQdRSFzLgicB9rBuSBwHqhhc36rknNB4DxQgvNAlZJ1LrjSVpIkSZIkSZKSiCttJUmSJEmSJCmJWLSVJEmSJEmSpCRi0VaSJEmSJEmSkohFW0mSJEmSJElKIhZtJUmSJEmSJCmJWLQVAJs2bWLo0KEMHjyYAQMG8PDDD4cdSSFYvnw5J5xwAn379mXgwIH89a9/DTuSQvTd736XVq1a8b3vfS/sKArRK6+8Qq9evejZsyePPPJI2HGURHyOUEPgNbAqeR2sSv5+UyWvg7UrdfkcEQmCIKj1/0VJLxaLUVpaSlZWFlu3bqV///588skntG7dOuxoqkOrVq1i9erVDB48mDVr1nDooYcyf/58mjZtGnY0heDNN99k8+bN/PnPf+Zvf/tb2HEUgoqKCvr27cubb75JixYtOPTQQ/n444/JyckJO5qSgM8Ragi8BlYlr4NVyd9vAq+DtXt1+RzhSlsBkJKSQlZWFgAlJSXEYjGs5zc+HTt2ZPDgwQC0a9eOnJwc1q9fH24ohWbYsGE0b9487BgK0eTJk+nXrx+dO3emefPmnHbaabz++uthx1KS8DlCDYHXwKrkdbAq+ftN4HWwdq8unyMs2jYQ77zzDmeccQadOnUiEonwj3/8Y6cx9913H927dyczM5O8vDzefffdasc3btzIoEGD6NKlCzfccANt2rSpo/SqKTUxDypNmTKFeDxObm5uLadWbajJuaD6a3/nwcqVK+ncuXPV1126dGHFihV1EV37yecANRZeA6uS18ECf/9pB6+DG6eG9hxg0baB2LJlC4MGDeJPf/rTLo+PHz+ea6+9lptvvplp06Zx7LHHMmLECPLz86vGtGzZks8++4wlS5bwzDPPsHr16rqKrxpSE/MAYN26dVx44YU89NBDdRFbtaCm5oLqt/2dB7tabRaJRGo1s2pGTTwH5OXl0b9//51uK1eurKuHIe2V18Cq5HWwwGtg7eB1cOPU4K6BAzU4QPDiiy9W23fYYYcFo0ePrravd+/ewY033rjLc4wePTp4/vnnayui6sC+zoOSkpLg2GOPDZ588sm6iKk6sD/PCW+++WZw9tln13ZE1YF9mQfvv/9+cOaZZ1Ydu/rqq4Onn3661rOqZtXEdcHu+ByhZOI1sCp5Hawg8BpYO3gd3Dg1hGtgV9o2AmVlZUydOpXhw4dX2z98+HA++OADAFavXk1xcTEAxcXFvPPOO/Tq1avOs6r2fJ15EAQBF198MSeeeCKjRo0KI6bqwNeZC2r4vs48OOyww5g1axYrVqxg06ZNTJgwgVNOOSWMuKpBPgeosfAaWJW8Dhb4+087eB3cONXH54DUsAOo9hUWFhKLxWjfvn21/e3bt6egoACAL774gksuuYQgCAiCgCuvvJKBAweGEVe15OvMg/fff5/x48czcODAqt4vf/nLXxgwYEBdx1Ut+jpzAeCUU07h008/ZcuWLXTp0oUXX3yRoUOH1nVc1ZKvMw9SU1O56667GDZsGPF4nBtuuMFPVG8Avu5zwN74HKFk5zWwKnkdLPAaWDt4Hdw41cdrYIu2jchX+68EQVC1Ly8vj+nTp4eQSnVtT/PgmGOOIR6PhxFLIdjTXAD8dNRGYm/zYOTIkYwcObKuY6kO7O1nvzc+R6i+8BpYlbwOFngNrB28Dm6c6tM1sO0RGoE2bdqQkpKy0ysHa9as2ekVBjVczgNVci4InAeNmT97NRbOdVVyLgicB9rBudA41cefu0XbRiA9PZ28vDwmTZpUbf+kSZM46qijQkqluuY8UCXngsB50Jj5s1dj4VxXJeeCwHmgHZwLjVN9/LnbHqGB2Lx5M4sWLar6esmSJUyfPp2cnBy6du3KmDFjGDVqFEOGDOHII4/koYceIj8/n9GjR4eYWjXNeaBKzgWB86Ax82evxsK5rkrOBYHzQDs4FxqnBvdzD9QgvPnmmwGw0+2iiy6qGnPvvfcG3bp1C9LT04NDDz00ePvtt8MLrFrhPFAl54KCwHnQmPmzV2PhXFcl54KCwHmgHZwLjVND+7lHgiAIaroQLEmSJEmSJEnaN/a0lSRJkiRJkqQkYtFWkiRJkiRJkpKIRVtJkiRJkiRJSiIWbSVJkiRJkiQpiVi0lSRJkiRJkqQkYtFWkiRJkiRJkpKIRVtJkiRJkiRJSiIWbSVJkiRJkiQpiVi0lSRJkiRJkqQkYtFWkpLU0qVLiUQiTJ8+vUbGPvHEE7Rs2bLavoceeojc3Fyi0Sjjxo3br7ySJEnS/vIaWJISLNpKUg24+OKLiUQiRCIRUlNT6dq1Kz/96U/ZsGFD2NGqnHvuuSxYsKDq6+LiYq688kp+/vOfs2LFCn784x9zwgkncO2114YXUpIkSfWG18CSVHtSww4gSQ3FqaeeyuOPP05FRQVz5szhRz/6ERs3buTZZ58NOxoATZo0oUmTJlVf5+fnU15ezumnn07Hjh1DTCZJkqT6ymtgSaodrrSVpBqSkZFBhw4d6NKlC8OHD+fcc89l4sSJVccff/xx+vTpQ2ZmJr179+a+++6rdv/JkydzyCGHkJmZyZAhQ5g2bVq14xs2bOCCCy6gbdu2NGnShJ49e/L4449XG7N48WKGDRtGVlYWgwYN4sMPP6w69uW3hj3xxBMMGDAAgB49ehCJRLj44ot5++23+eMf/1i1YmLp0qU1+B2SJElSQ+M1sCTVDlfaSlItWLx4Ma+99hppaWkAPPzww9x222386U9/4pBDDmHatGlcdtllNG3alIsuuogtW7bw7W9/mxNPPJGnnnqKJUuWcM0111Q756233sqcOXN49dVXadOmDYsWLWLbtm3Vxtx8883ceeed9OzZk5tvvpnzzz+fRYsWkZpa/en+3HPPJTc3l5NPPpnJkyeTm5tLkyZNWLBgAf379+eOO+4AoG3btrX4XZIkSVJD4jWwJNUci7aSVENeeeUVmjVrRiwWo6SkBIC7774bgF/96lfcddddnHXWWQB0796dOXPm8OCDD3LRRRfx9NNPE4vFeOyxx8jKyqJfv3588cUX/PSnP606f35+PocccghDhgwB4IADDtgpw/XXX8/pp58OwO23306/fv1YtGgRvXv3rjauSZMmtG7dGkhclHbo0AGA9PR0srKyqr6WJEmS9sRrYEmqHRZtJamGDBs2jPvvv5+tW7fyyCOPsGDBAq666irWrl3L8uXLueSSS7jsssuqxldUVJCdnQ3A3LlzGTRoEFlZWVXHjzzyyGrn/+lPf8rZZ5/Np59+yvDhwznzzDM56qijqo0ZOHBg1XZlj641a9bsdMEqSZIk1QSvgSWpdtjTVpJqSNOmTTnooIMYOHAg99xzD6Wlpdx+++3E43Eg8faw6dOnV91mzZrFRx99BEAQBHs9/4gRI1i2bBnXXnstK1eu5KSTTuL666+vNqbyrWgAkUgEoOr/lyRJkmqa18CSVDss2kpSLbntttu48847icVidO7cmcWLF3PQQQdVu3Xv3h2Avn378tlnn1Xrz1V5Mftlbdu25eKLL+app55i3LhxPPTQQzWaOT09nVgsVqPnlCRJUuPhNbAk1QzbI0hSLTnhhBPo168fv/nNb/if//kfrr76alq0aMGIESMoLS1lypQpbNiwgTFjxvCDH/yAm2++mUsuuYRbbrmFpUuXcuedd1Y73y9/+Uvy8vLo168fpaWlvPLKK/Tp06dGMx9wwAF8/PHHLF26lGbNmpGTk0M06ut7kiRJ+nq8BpakmuGzkCTVojFjxvDwww9zyimn8Mgjj/DEE08wYMAAjj/+eJ544omqVQbNmjXj5ZdfZs6cORxyyCHcfPPN/O53v6t2rvT0dG666SYGDhzIcccdR0pKCs8991yN5r3++utJSUmhb9++tG3blvz8/Bo9vyRJkho+r4Elaf9Fgq/TREaSJEmSJEmSVCdcaStJkiRJkiRJScSirSRJkiRJkiQlEYu2kiRJkiRJkpRELNpKkiRJkiRJUhKxaCtJkiRJkiRJScSirSRJkiRJkiQlEYu2kiRJkiRJkpRELNpKkiRJkiRJUhKxaCtJkiRJkiRJScSirSRJkiRJkiQlEYu2kiRJkiRJkpRE/j8M27OMBVMxgQAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 1400x500 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(14, 5))\n",
     "ax = fig.add_subplot(121, title=\"Cosmology age\", xlabel=\"Redshift\", ylabel=r\"age  [Gyr]\")\n",
@@ -439,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,43 +311,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$40 \\; \\mathrm{mag}$"
-      ],
-      "text/plain": [
-       "<Quantity 40. mag>"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "d.distmod"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.19781979298501276"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "d.z  # the redshift"
    ]
@@ -502,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,20 +348,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'get', 'get_cosmology_from_string', 'set', 'validate'}"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# the public methods\n",
     "{x for x in dir(default_cosmology) if not x.startswith(\"_\")}"
@@ -541,20 +367,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "FlatLambdaCDM(name=\"Planck18\", H0=67.7 km / (Mpc s), Om0=0.31, Tcmb0=2.725 K, Neff=3.05, m_nu=[0.   0.   0.06] eV, Ob0=0.049)"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "default_cosmology.get()  # to get the default Cosmology"
    ]
@@ -569,18 +384,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "New:  WMAP5\n",
-      "Reverted:  Planck18\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with default_cosmology.set(\"WMAP5\"):\n",
     "    cosmo = default_cosmology.get()\n",
@@ -599,20 +405,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.19781979298501276"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "d = Distance(1 * u.Gpc)\n",
     "dz = d.z\n",
@@ -621,17 +416,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WMAP5 - Planck18: 2.88% difference\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with default_cosmology.set(\"WMAP5\"):\n",
     "    print(f\"WMAP5 - Planck18: {100 * (d.z / dz - 1):.3}% difference\")"
@@ -646,17 +433,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "475.1400199368446 Mpc\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with default_cosmology.set(\"Planck13\"):\n",
     "    print(Distance(z=0.1))"
@@ -673,23 +452,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$105 \\; \\mathrm{\\frac{Mpc}{h_{100}}}$"
-      ],
-      "text/plain": [
-       "<Quantity 105. Mpc / littleh>"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "distance = 105 * (u.Mpc/u.littleh)\n",
     "distance"
@@ -697,17 +462,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Cannot convert incompatible units.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This raises an error because they are different units.\n",
     "try:\n",
@@ -725,23 +482,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$150 \\; \\mathrm{Mpc}$"
-      ],
-      "text/plain": [
-       "<Quantity 150. Mpc>"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This succeeds using equivalencies.\n",
     "H0_70 = 70 * u.km / u.s / u.Mpc\n",
@@ -758,23 +501,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$105 \\; \\mathrm{\\frac{Mpc}{h_{100}}}$"
-      ],
-      "text/plain": [
-       "<Quantity 105. Mpc / littleh>"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "(150 * u.Mpc).to(u.Mpc/u.littleh, u.with_H0(H0_70))"
    ]
@@ -788,23 +517,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$1 \\; \\mathrm{L_{\\odot}}$"
-      ],
-      "text/plain": [
-       "<Quantity 1. solLum>"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "luminosity = 0.49 * u.Lsun * u.littleh**-2\n",
     "luminosity.to(u.Lsun, u.with_H0(H0_70))"
@@ -819,18 +534,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "150.0 Mpc\n",
-      "155.1877032219923 Mpc\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(distance.to(u.Mpc, u.with_H0(H0_70)),\n",
     "      distance.to(u.Mpc, u.with_H0(Planck18.H0)), sep=\"\\n\")"
@@ -845,18 +551,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "distance: 155.1877032219923 Mpc\n",
-      "luminosity: 1.0703654769474296 solLum\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with u.add_enabled_equivalencies(u.with_H0(Planck18.H0)):\n",
     "    print(f\"distance: {distance.to(u.Mpc)}\",\n",
@@ -888,7 +585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -897,20 +594,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.3277585104925771"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "z_at_value(Planck18.age, 10*u.Gyr)"
    ]
@@ -924,7 +610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -940,20 +626,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(50, 100)"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "perturb_Om0 = np.linspace(-0.2, 0.2, num=50)  # the perturbation\n",
     "zs = np.empty((50, 100))  # preload derived redshift arrays\n",
@@ -967,20 +642,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjcAAAHFCAYAAAAOmtghAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAA9hAAAPYQGoP6dpAAC0KUlEQVR4nOzdd3hUVfrA8e+dmp6Q3gOEFhKKVAMiorSASFFBiAhYcVVU3MXC2hB1d/nprq4LiytFOioCglQREEWU3juBkN7LzGTqPb8/JhmIFAHRUM7neXx07px777k349x33tMUIYRAkiRJkiTpBqGp6wpIkiRJkiRdTTK4kSRJkiTphiKDG0mSJEmSbigyuJEkSZIk6YYigxtJkiRJkm4oMriRJEmSJOmGIoMbSZIkSZJuKDK4kSRJkiTphiKDG0mSJEmSbigyuJFuKjNnzkRRFM8/Op2O2NhYRo0aRXZ29lU91+TJk5k5c+ZVPebZ6tevz9133/27Hf9siqLwxhtvXLTMyZMnPff1QmUffvhhT5krsWLFigse+5133mHJkiVXdNzfwmaz8dFHH3HbbbdRr149DAYDMTExDB48mI0bN/7h9bkR1dXfVrp+yeBGuinNmDGDH3/8kbVr1/LYY48xf/58unTpgtlsvmrn+L2Dm2uVv78/M2fORFXVWttNJhOff/45AQEBV3zsFStW8Oabb573vbp4ABYVFdG5c2fGjh1LSkoKM2fOZN26dbz33ntotVruuusudu/e/YfW6UYkgxvpcunqugKSVBdSUlJo164dAN26dcPlcvHWW2+xZMkS0tPTf9OxLRYLPj4+V6OadXL832rIkCF88sknrFu3jh49eni2L1y4EJfLxYABA5gzZ04d1vDSuVwunE4nRqPxvO8/9NBD7N69m9WrV3PnnXfWeu+BBx5g7Nix1KtX74+oqiRJZ5GZG0kCbr31VgBOnToFgBCCyZMn07p1a7y9valXrx733XcfJ06cqLXfHXfcQUpKCt999x2dOnXCx8eHhx9+mPr167N//342btzoaYapX78+cKZp7OTJk7WOtWHDBhRFYcOGDb96/LMtXryYli1b4uXlRcOGDfnwww/Pub6Kigr+/Oc/06BBA0+zyXPPPXdOpqqiooLHHnuMkJAQ/Pz86N27N0eOHLmse9m0aVM6derE9OnTa22fPn06gwYNIjAw8Jx9Fi5cSM+ePYmKisLb25ukpCReeumlWvUbOXIk//nPfwBqNS3WNIeZzWY+/fRTz/Y77rjDs29eXh5PPPEEsbGxGAwGGjRowJtvvonT6fSUqTnOP/7xDyZOnEiDBg0wGo2sX7/+vNe5fft2Vq5cySOPPHJOYFOjffv2xMfHe17v27eP/v37U69ePby8vGjdujWffvpprX1qPgfz5s3jxRdfJCoqCj8/P/r160d+fj6VlZU8/vjjhIaGEhoayqhRozCZTLWOoSgKTz/9NFOnTqVJkyYYjUaaN2/OggULzqnj5dRp/vz5jB8/nujoaAICAujevTuHDx8+55jffPMNd911FwEBAfj4+NC5c2fWrVtXq8wbb7yBoijs37+foUOHEhgYSEREBA8//DDl5eW1ruVif1tJOi8hSTeRGTNmCEBs3bq11vYPPvhAAOLjjz8WQgjx2GOPCb1eL1544QWxatUqMW/ePNGsWTMREREh8vLyPPt17dpVBAcHi7i4OPHvf/9brF+/XmzcuFHs2LFDNGzYUNxyyy3ixx9/FD/++KPYsWNHrTpkZGTUqsP69esFINavX/+rxxdCiISEBBETEyPi4+PF9OnTxYoVK0R6eroAxKRJkzzHMJvNonXr1iI0NFS8//774ptvvhEffPCBCAwMFHfeeadQVVUIIYSqqqJbt27CaDSKt99+W6xZs0a8/vrromHDhgIQr7/++kXvbUZGhufc06ZNE15eXqKkpEQIIcShQ4cEIL799lvx1FNPiV9+9bz11lvin//8p/j666/Fhg0bxH//+1/RoEED0a1bN0+ZY8eOifvuu08Annv6448/CqvVKn788Ufh7e0t+vTp49m+f/9+IYQQubm5Ii4uTiQkJIipU6eKb775Rrz11lvCaDSKkSNHnlP/mJgY0a1bN/HFF1+INWvWnPN3qvHOO+8IQKxcufKi96XGoUOHhL+/v0hMTBSzZs0SX3/9tRg6dKgAxN///ndPuZrPQUJCghg5cqRYtWqV+O9//yv8/PxEt27dRI8ePcSf//xnsWbNGvH3v/9daLVa8cwzz9Q6FyDi4uJE8+bNxfz588VXX30levfuLQDx+eefX3Gd6tevL9LT08XXX38t5s+fL+Lj40Xjxo2F0+n0lJ09e7ZQFEUMGDBAfPnll2LZsmXi7rvvFlqtVnzzzTeecq+//roARNOmTcVrr70m1q5dK95//31hNBrFqFGjPOUu9reVpAuRwY10U6kJLLZs2SIcDoeorKwUy5cvF2FhYcLf31/k5eWJH3/8UQDivffeq7Xv6dOnhbe3txg3bpxnW9euXQUg1q1bd865kpOTRdeuXS9Yh0sNbi50/ISEBKEoiti1a1et7T169BABAQHCbDYLIYR49913hUajOSeg++KLLwQgVqxYIYQQYuXKlQIQH3zwQa1yb7/99mUHN5WVlcLPz0989NFHQggh/vKXv4gGDRoIVVXPG9ycTVVV4XA4xMaNGwUgdu/e7XnvYvv6+vqKESNGnLP9iSeeEH5+fuLUqVO1tv/f//2fADwPypr6JyYmCrvdftFrFUKI0aNHC0AcOnToV8sKIcQDDzwgjEajyMzMrLU9LS1N+Pj4iLKyMiHEmc9Bv379apV77rnnBCDGjBlTa/uAAQNEcHBwrW2A8Pb2rhWIO51O0axZM9GoUaMrrlOfPn1qlfvss888waYQ7kA6ODj4nLq7XC7RqlUr0aFDB8+2muDmH//4R62yf/rTn4SXl5cn6Bbiwn9bSboQ2Swl3ZRuvfVW9Ho9/v7+3H333URGRrJy5UoiIiJYvnw5iqLw4IMP4nQ6Pf9ERkbSqlWrWs1GAPXq1btgs8TVcLHjJycn06pVq1rbhg0bRkVFBTt27ABg+fLlpKSk0Lp161rX06tXr1rNYDXNL7/sczRs2LDLrrOfnx/3338/06dPx+l0MmvWLEaNGnXBUVInTpxg2LBhREZGotVq0ev1dO3aFYCDBw9e9vnPtnz5crp160Z0dHSt609LSwM4Z0TTPffcg16v/03nPJ9vv/2Wu+66i7i4uFrbR44cicVi4ccff6y1/Zcj4ZKSkgDo27fvOdtLSkrOaZq66667iIiI8LzWarUMGTKEY8eOkZWVdUV1uueee2q9btmyJXCmOXfz5s2UlJQwYsSIWvdaVVV69+7N1q1bz2kKPd8xrVYrBQUFSNKVkh2KpZvSrFmzSEpKQqfTERERQVRUlOe9/Px8hBC1Hgxna9iwYa3XZ+/7e7jY8SMjIy+4rbi4GHBfz7Fjxy74wC4qKvKU1+l0hISE/Oo5LsUjjzzCbbfdxttvv01hYSEjR448bzmTyUSXLl3w8vJi4sSJNGnSBB8fH06fPs2gQYOoqqq6ovPXyM/PZ9myZb96/TUu9e9Z05cmIyODpk2b/mr54uLi8x47Ojra8/7ZgoODa702GAwX3W61WvHz8/Ns/7XPRmxs7GXX6ZefjZqO1jV/o/z8fADuu+++c45Zo6SkBF9f30s+piRdCRncSDelpKQkz2ipXwoNDUVRFDZt2nTeUTK/3Ha5c7Z4eXkB7vlRzvbLh+ylHD8vL++C22oeGqGhoXh7e5/TwbdGaGiop7zT6aS4uLjWA+d857gUnTt3pmnTpkyYMIEePXqckx2o8e2335KTk8OGDRs82RqAsrKyKzrvL4WGhtKyZUvefvvt875f8yCvcal/z169evHKK6+wZMkSevfu/avlQ0JCyM3NPWd7Tk6Op55X06V8Nq52nWrK//vf//Z00v+lC/1okKSrSQY3kvQLd999N3/729/Izs5m8ODBV3wco9F43l+fNaOm9uzZU+sX/1dffXXZ59i/fz+7d++u1TQ1b948/P39adOmDeC+nnfeeYeQkBAaNGhwwWN169aNf/zjH8ydO5cxY8bUOt6V+utf/8oXX3zBU089dcEyNcHEL4PGqVOnnlP27F/13t7e57x3vvt99913s2LFChITE6/qsOw2bdqQlpbGtGnTGDx48HmbDrdt20Z4eDjx8fHcddddLF68mJycnFoB1axZs/Dx8blgMHCl1q1bR35+vieYcLlcLFy4kMTERGJjYwGuep06d+5MUFAQBw4c4Omnn75q13Khv60kXYgMbiTpFzp37szjjz/OqFGj2LZtG7fffju+vr7k5uby/fff06JFC5588slfPU6LFi1YsGABCxcupGHDhnh5edGiRQvat29P06ZN+fOf/4zT6aRevXosXryY77///rLrGh0dzT333MMbb7xBVFQUc+bMYe3atfz973/3zIXz3HPPsWjRIm6//Xaef/55WrZsiaqqZGZmsmbNGl544QU6duxIz549uf322xk3bhxms5l27drxww8/MHv27MuuV40HH3yQBx988KJlOnXqRL169Rg9ejSvv/46er2euXPnnnfyuxYtWgDw97//nbS0NLRaLS1btsRgMNCiRQs2bNjAsmXLiIqKwt/f35M5Wrt2LZ06dWLMmDE0bdoUq9XKyZMnWbFiBf/97389D/vLNWvWLHr37k1aWhoPP/wwaWlp1KtXj9zcXJYtW8b8+fPZvn078fHxvP76657+P6+99hrBwcHMnTuXr7/+mn/84x/nHSL/W4SGhnLnnXfy6quv4uvry+TJkzl06FCt4eBXu05+fn78+9//ZsSIEZSUlHDfffcRHh5OYWEhu3fvprCwkClTplz2tVzobytJF1TXPZol6Y90oaHg5zN9+nTRsWNH4evrK7y9vUViYqJ46KGHxLZt2zxlunbtKpKTk8+7/8mTJ0XPnj2Fv7+/Z2hvjSNHjoiePXuKgIAAERYWJp555hnx9ddfn3e01IWOn5CQIPr27Su++OILkZycLAwGg6hfv754//33zylrMpnEX//6V9G0aVNhMBhEYGCgaNGihXj++edrjagpKysTDz/8sAgKChI+Pj6iR48enmHclzNa6mLON+Jp8+bNIjU1Vfj4+IiwsDDx6KOPih07dghAzJgxw1POZrOJRx99VISFhQlFUWqNOtu1a5fo3Lmz8PHxEUCtkWqFhYVizJgxokGDBkKv14vg4GDRtm1bMX78eGEymS6r/r9UVVUlPvzwQ5GamioCAgKETqcT0dHRYtCgQeLrr7+uVXbv3r2iX79+IjAwUBgMBtGqVata1yfEmZFJZw/ZFuLCn92aUUeFhYWebYB46qmnxOTJk0ViYqLQ6/WiWbNmYu7cuefU/7fUqeae/bL8xo0bRd++fUVwcLDQ6/UiJiZG9O3bt9b+56v32dd59mjCi/1tJel8FCGE+IPjKUmSJOl3pCgKTz31FB999FFdV0WS6oQcCi5JkiRJ0g1FBjeSJEmSJN1QZIdiSZKkG4zsbSDd7GTmRpIkSZKkG4oMbiRJkiRJuqHI4EaSJEmSpBvKTdfnRlVVcnJy8Pf3v+xp8yVJkiRJqhtCCCorK4mOjkajuXhu5qYLbnJyci64xo0kSZIkSde206dP/+qs4jddcOPv7w+4b05AQEAd10aSJEmSpEtRUVFBXFyc5zl+MTddcFPTFBUQECCDG0mSJEm6zlxKlxLZoViSJEmSpBuKDG4kSZIkSbqhyOBGkiRJkqQbyk3X5+ZSuVwuHA5HXVdDuo7o9Xq0Wm1dV0OSJOmmJ4ObXxBCkJeXR1lZWV1XRboOBQUFERkZKedQkiRJqkMyuPmFmsAmPDwcHx8f+ZCSLokQAovFQkFBAQBRUVF1XCNJkqSblwxuzuJyuTyBTUhISF1XR7rOeHt7A1BQUEB4eLhsopIkSaojskPxWWr62Pj4+NRxTaTrVc1nR/bXkiRJqjsyuDkP2RQlXSn52ZEkSap7MriRJEmSJOmGIoMbSZIkSZJuKDK4uQFt3rwZRVHo3bv3ed/fs2cPgwYNIiQkBC8vL5KTk5k0aRJOp/MPrumlmTx5Mg0aNMDLy4u2bduyadOmi5b/7rvv6NevH9HR0SiKwpIlS66ojCRJknR9ksHNDWj69OkMHTqU9evXk5mZWeu9jRs3cuutt+Lt7c3SpUvZvXs348aN4//+7/8YNGgQqqrWUa3Pb+HChTz33HOMHz+enTt30qVLF9LS0s65rrOZzWZatWrFRx999JvKSJIkSZdPVdW6f5aIm0x5ebkARHl5+TnvVVVViQMHDoiqqqo6qNnVYTKZhJ+fn/jpp59E7969xZtvvul5z+l0igYNGoj09PRz9tu/f7/Q6/Xik08++SOr+6s6dOggRo8eXWtbs2bNxEsvvXRJ+wNi8eLFv7nMpboRPkOSJElXymazieLiYlFaWipUVb2qx77Y8/uXZObmBrNw4UIiIyPp0KED6enpzJgxAyEEAD///DMZGRn85S9/OWe/5s2b06dPHxYuXPi71Oudd97Bz8/vov/8srnJbrezfft2evbsWWt7z5492bx58+9ST0mSJOnyqaqKyWSipKSE0tJSKioqPM+euiAn8fsVQgiqHK46Obe3XnvZQ4unTZtGeno6AAMGDOCJJ55g3bp1dO/enYyMDAAaN2583n2bNGnC0qVLL+t8y5cv54UXXkBVVV588UUeffTR85YbPXo0gwcPvuixYmJiar0uKirC5XIRERFRa3tERAR5eXmXVU9JkiTp6hNC4HA4MJlMmEwmLBYLTqcTrVYrg5trWZXDRfPXVtfJuQ9M6IWP4dL/RIcPH2bz5s3MmDEDAD8/P/r378/06dPp3r07AQEBAJSUlJx3osLS0lJPmUvhdDoZO3Ys69evJyAggDZt2jBo0CCCg4PPKRscHHze7ZfilwGeEELOJyNJklTHXC4XZrPZE9TY7fZa3891+T0tm6VuINOmTaN9+/Y0adLEsy09PZ0vv/yS0tJSUlNT0ev1LFu27Jx9XS4Xa9as4bbbbvNsS0tLY+zYsdx66600a9aMrVu3cs8995CQkMDHH3/Mzz//THJyMjExMfj7+9OnTx9Wrz5/IHglzVKhoaFotdpzsjQFBQXnZHMkSZKkP4YQAqvVSklJCSUlJZSXl1NVVYWqqggh6jRjU0Nmbn6Ft17LgQm96uzcl8rpdDJr1ixeeumlWtt79eqFv78/c+fO5emnn2bMmDFMnDiR/v37Ex0d7Sn3z3/+k+LiYp5//nnPtn379jFkyBDef/99HnroIV588UWWLVvG0aNHefLJJ3nhhRdqNSXFxsaSnZ193vpdSbOUwWCgbdu2rF27loEDB3q2r127lv79+//6TZEkSZKuqrOzNWazGZvNViuYURQFa6ULYbVBfN3VUwY3v0JRlMtqGqory5cvJz8/n5SUFPbt21frvS5dujBt2jRGjhzJmDFj2LJlC926dWP+/Pm0adOGSZMmMX78eKZOnYrBYMDlcmEymTAYDIwcORIALy8vnn32WXx9fTEajQQGBp43Or9QGvJKm6XGjh3L8OHDadeuHampqXz88cdkZmYyevRoT5mPPvqIxYsXs27dOgBMJhPHjh3zvJ+RkcGuXbsIDg4mPj7+kstIkiRJbkIIbDYblZWVmM1mqqqqzpkbTaiC7L0WMraY8QvRk9QqEY2mbhqIrv2ntnRJpk2bBkCPHj0uWGbYsGG1mqQ+/PBDZs6cybhx4wB4+OGHAfeDPjs7m/bt23vK7t27lwkTJnj+OyUlhZiYmFqZmqysLDp27Hj1LgoYMmQIxcXFTJgwgdzcXFJSUlixYgUJCQmeMkVFRRw/ftzzetu2bXTr1s3zeuzYsQCMGDGCmTNnXnIZSZIkCc8P3rOzNVD7x6ypyMmR9ZVU5rsXDdZoFawWJ36BdRNmKOJaaBz7A1VUVBAYGEh5efk5nWetVisZGRme2XBvZlOnTqWoqIjx48cjhCAxMZETJ04A8Nprr5GYmEh6ejpJSUls2LDB06F4y5YthISE1HHt6478DEmSdKOo6VtzdrbG5ao9elh1QeZWM6d3WhAqaA0KDTv50eTWMOLj469q5uZiz+9fkpkb6bz2799P9+7dATh58iT169f3vLdv3z4GDBiATqfjvffeo1u3bqiqyrhx427qwEaSJOlG4XQ6a2VrakZCna0s286xDWaqyt0BT2hDI427+mP0u/T+or8Xmbk5i/zVLf1W8jMkSdL17GLZmppmKIdV5cQPJvIOWgEw+GhofIc/oQ2NKIri7qvq40NcXBxa7dULdGTmRpIkSZKky1KTramsrDzvvDWqqlJ4zMbxTSYcVe68SFSKNw1TfdEZNZ5yNcPB63KeGxncSJIkSdJNrCZbU1FRUStbU5OFAbBWuji20UTJKTsAPvW0NOnmT2C0oVYQoygKYt8+XHo9nDXw448mgxtJkiRJukk5nU4qKys9swzXjISC6gyMKsjZZ+XUTxZcDoGigbi2PsS39UGj/UVmprwcZs1Cs2EjzvBw1B490Pj5/cFX5CaDG0mSJEm6yQghqKqq8gQ2VqsVVVXdmZfqrriWElf18G73fDYBkTqa3BmAX4i+Vudi4XKhrP0GZd48FLMZoSho27VDqGqdXBvI4EaSJEmSbio12Zpf9q2pIVyQud1C1s4q9/BuvULDTr5EpXh7gh9Pn5oTGWj+9zHKUfekqKJBfcTjj2O45Ra0dZS1ARncSJIkSdJNQQiBxWLxDPE+30ioilwHR9abqCpzbw+pb6BRVz+8A/SAu1OxRqNBqaqCBQtQVq5CUVWEtzcMGwq9e6NcxRFSV0oGN5IkSZJ0g3M4HJhMJioqKrBYLDgcDk+2RlEUnDaVk1ss5O4/M7w78XY/QhsaajVVaRQF8cNmNDNmoJSWAiA6dUKMGgnBwbVWBJejpSRJkiRJuupqsjU1fWtqVu8+W9EJG8c3mbGb3dsjmxupf6svei9NrRmGlfx8lE8+QbNzl/vYkZGIxx6F1q1rNVdpNJo6Hw4ugxtJkiRJugE5HI7z9q3RaNxz0thMLo5tMlF8wj282ztQQ5M7AwiKMXgyNUIIFKcTZelXKF8uQrE7EDodYuBAxMABaLy8UBTF0xkZYHvpdgwWQ50uQiyDG0mSJEm6gaiqSlVVFRUVFedka2oyLHkHrJzYbMZldw/vjm3tTUJ7XzQ6pfYyC3v3ovlkGkpODgCiZUvEY48ioqJqNVcB5Fpz+fT0p+ws20mwIZi0lDT8jf5/6LXXkMGNJEmSJN0gHA6HJ6g5e96amj4wVWUujm4wUZ7jXr3bL1xHk27++IXWDgc0FRXw6adovtsEgAgKQowcCbd1BkWBs/rrVDmrWJK3hOV5y3EKJ1pFS7fIbijUXZ+bq7dcp3TN2Lx5M4qi0Lt37/O+v2fPHgYNGkRISAheXl4kJyczadIknE7nH1zTSzN58mTPWk1t27Zl06ZNFy3/3Xff0a9fP6Kjo1EUhSVLlpxTprKykueee46EhAS8vb3p1KkTW7duvezjSJIkXQtUVcVkMlFUVERJSQnl5eXYbDZPUONyqmRut7B9YSnlOQ40OmjQyZdb7g3yBDaKoqAIgbJmDcqYZ9F8twmhKKhpvVE/+Bd0uc0d2HBmdNUPxT8wdt9YluQuwSmctA5szXsp7zGq4Sh89D51dTtk5uZGNH36dIYOHcqiRYvIzMys1e65ceNG0tLSGDhwIEuXLiUsLIwtW7Ywbtw4Nm3axJIlS67qEvW/1cKFC3nuueeYPHkynTt3ZurUqaSlpXHgwIELtueazWZatWrFqFGjuPfee89b5tFHH2Xfvn3Mnj2b6Oho5syZQ/fu3Tlw4AAxMTGXfBxJkqS6dna2xmQy4XA4ao1Wqsh3cHyjGXOxe3h3UJyexl398ArQ1urwK05koP3f/1COHnW/btgQ9fHHoFEjTxNUzb8zqzL59PSnHKg8AEC4MZyR8SNpG9S2TkdJ1ZCrgp/lRljR2Ww2ExkZybp163j99ddJTU3ltddeA8DlctG4cWM6derEnDlzau134MABWrduzZQpU3jkkUfqourn1bFjR9q0acOUKVM825KSkhgwYADvvvvur+6vKAqLFy9mwIABnm1VVVX4+/uzdOlS+vbt69neunVr7r77biZOnHhJxzmfG+EzJEnS9UFVVc9IqMrKSs8sw573nXBqq4WcPVYQoDMqJHbxI7yJsXYAUlWFZuFnKCtWoAiB8PZGDBuK6NkToak9YsrkNPFFzhesLliNQGDQGBgYNZB+Uf0waAyecj4+PsTHx1/VQEeuCn41CQEOS92cW+/jSQFeqoULFxIZGUmHDh1IT0/n1Vdf5dVXX0VRFH7++WcyMjJYvHjxOfs1b96cPn36sHDhwt8luHnnnXd45513Llpm5cqVdOnSxfPabrezfft2XnrppVrlevbsyebNm6+4Lk6nE5fLdU7w4e3tzffff3/Fx5UkSfqjnC9bc7ayLAfHvzNjrXAHO2GNjTTs7IvBxx2oCCFACJSff0Y7YyZKSQkAamoqPDzKPWcNoFSXFQg2FG1gQfYCKpwVANxa71YejH2QMK8wz3lrMjuqqsqh4Nc0hwXeia6bc7+SAwbfy9pl2rRppKenAzBgwACeeOIJ1q1bR/fu3cnIyACgcePG5923SZMmLF269LLOt3z5cl544QVUVeXFF1/k0UcfPW+50aNHM3jw4Iseq6Y5qEZRUREul4uIiIha2yMiIsjLy7usep7N39+f1NRU3nrrLZKSkoiIiGD+/Pn89NNPF7w3kiRJ14KabE1NYGO1WnE6nZ7sisPq4uSPVRQcdg/vNvppSLzdl5D6RuBMXxkKCtBMm45mxw4AREQE6iOPQJtb3O+f1QR13HycGZkzOG45DkCMVwyjEkbRIqCFp141xxVC4FW0Dx+dkKuCS1fH4cOH2bx5MzNmzADAz8+P/v37M336dLp37+5J45WUlODjc25Hr9LS0l9N9Z3N6XQyduxY1q9fT0BAAG3atGHQoEEEBwefUzY4OPi82y/FLyP/q/FrYPbs2Tz88MPExMSg1Wpp06YNw4YNY0f1/+iSJEnXGrvdXitb43Q6a02aV3zCwYnvzTiq3L1NolKMJHT0RWc4M2RbOBxov16B5osvUOx2hFaLGNAfdeAghEHvGWWkKAoVjgrmZ89nfdF6ALw13twXfR+9I3qj1+przW0DoDPnEb5nMoGZa3D6xUDbu8FQN52KZXDza/Q+7gxKXZ37MkybNo327dvTpEkTz7b09HTuvfdeSktLSU1NRa/Xs2zZMp588sla+7pcLtasWcOgQYM829LS0khKSmLz5s2UlZUxe/Zs3nrrLXbv3s348eNJSUkhOTnZk3Hp06cPq1evZujQoefU7UqapUJDQ9FqtedkaQoKCs7J5lyuxMRENm7ciNlspqKigqioKIYMGUKDBg1+03ElSZKuNlVVPd9VZrP5nGyNtdJJxg9VlJx0N015B2lpfIcvAVHu9aA8SyIcOuTuMHw6CwDRvDmuxx+DmBhPgATgEi6+KfiGz3M+x+wyA3B7yO2kx6UTqAt071sdVAEoDguhh2YRfHg+GpcNgUJVVHt8nTYZ3FyzFOWym4bqgtPpZNasWef0T+nVqxf+/v7MnTuXp59+mjFjxjBx4kT69+9PdPSZ5rZ//vOfFBcX8/zzz3u27du3jyFDhvD+++/z0EMP8eKLL7Js2TKOHj3Kk08+yQsvvFCrKSk2Npbs7Ozz1u9KmqUMBgNt27Zl7dq1DBw40LN97dq19O/f/9dvyiXw9fXF19eX0tJSVq9ezT/+8Y+rclxJkqSroSZbU1lZidls9vStqWkyyj9o4+SWKs9kfDG3eBHXxhuN9qy1nUwmtHPnoln3LQDC3x91xEOI229HOWupBCEEh0yHmHl6JplVmQDU967PqPhRNPVvWitLoygKqC4CT64gfO9/0VmLATCHt6HglufQRLfGzzvoj7tRvyCDmxvE8uXLyc/PJyUlhX379tV6r0uXLkybNo2RI0cyZswYtmzZQrdu3Zg/fz5t2rRh0qRJjB8/nqlTp2IwGHC5XJhMJgwGAyNHjgTAy8uLZ599Fl9fX4xGI4GBgZxvoN2FmouutFlq7NixDB8+nHbt2pGamsrHH39MZmYmo0eP9pT56KOPWLx4MevWrQPAZDJx7Ngxz/sZGRns2rWL4OBgz/Dx1atXI4SgadOmHDt2jL/85S80bdqUUaNGefa7lONIkiT9Hs7O1pxvTShbpeDYRjMVOe75yfzCdTTq6oNviO7MMHAhUL77Du2s2SiVle7j3tkNV3o6msBAT2dhjUZDib2EeVnz+L7EPajCV+vLkJghdA/rjkbR1BoKDuCdv53IXR/gVXYEALtfLAWtx2CKuR0UBS+5tpR0NUybNg2AHj16XLDMsGHDWLZsmef1hx9+yMyZMxk3bhwADz/8MOB+iGdnZ9O+fXtP2b179zJhwgTPf6ekpBATE1MrU5OVlUXHjh2v3kUBQ4YMobi4mAkTJpCbm0tKSgorVqwg4ayOakVFRRw/ftzzetu2bXTr1s3zeuzYsQCMGDGCmTNnAlBeXs7LL79MVlYWwcHB3Hvvvbz99tvo9frLOo4kSdLVZrPZPMO7a7I1nh+TArJ3W8nabkV1gUYH8e19iGnphUZ7pmmJnBy0//sEzf797t1iY3E9/hhK8+bu4d7VgYdTOFmdt5pFOYuwqlYUFO4MvZMhMUMI0J/pg1kTBOkqTxOx+yMCsjcC4NL7UdR8FGVNBiO0Z4aC1/VcN3Kem7PIOUrOmDp1KkVFRYwfPx4hBImJiZw4cQKA1157jcTERNLT00lKSmLDhg2eDsVbtmwhJCSkjmtfd+RnSJKkK3WhbE1N1sRc5OT4d1WYi9yT8QXG6GjU1RevAK3nGIrDgXbJUjRLl6I4nQiDAde99yL63Q06Xa2gY1/FPj7N+pRsq/tHaqJvIqPiRtHIr1GtPjUAWoeZ0AMzCD66EEV1IhQtZYkDKEx+FJdXvXMzO97exMXFXdVJYeU8N9Jvtn//frp37w7AyZMnqV+/vue9ffv2MWDAAHQ6He+99x7dunVDVVXGjRt3Uwc2kiRJV+pi2RqXQyV7p42sXWcm46uf6kN4U4OnCUoIgWbfPnTTpqHkugdhqLe0Rn3kUYgIh7NHVdmLmZs9ly2lWwDw1/kzNGYoXUO6olGqOwnXBCvCRdCJrwjf/wk6WykApsiO5LV6FkdQQ/f5q6+hJrAx2VVKHHbi/sD790syc3MW+atb+q3kZ0iSpMvxa31rKnKdHP/OgrXcvS2koZ6Gt/li9NV6sjpKRQW62XPQVK+7J+rVQx01EnHrrbUmgnWqTlYUrmBx7mJsqg0FhR5hPbg/+n789e7Vu8/OvvgVbCVi1wd4lbuz9jb/BPJbP4s5utM5K4IrioLdqfLVoQoW7imlfog3S5+5XWZuJEmSJOlmcna2xmQyYbfbPYGF0y7I/LmK/APuyfj0PgoNb/MhpIHhrKyKQLthA9o5c1HMZvcilz174npgCIpv9Sjf6gBkT8UeZmXNIteWC0AT3yY8nPAwCd4JZzI/1YGIoTKTyD0f4Z/j7lzsNARQlPIYJQ0HoGjd/RJVVfWUVwWsO1bJrJ0lFJjdHZyrnIJis50w/7r5kSeDG0mSJEn6A52dralZE8rlcnkCm9JMByc2WbCb3YFJRDMjCbd6oTWcGd6tycpC+8knaA4ddh+zfn1cjz0KjRu7l02oLldkL2J21my2lm0FIFAXSHpsOrcF31Yr+6IoCoqtnPADMwg59gWKcCEULSWN7qUo+RFUY+A5zU+qqrItu4oZO0rIKHUHYRH+Bp7r3pjB7RPQauquU7EMbiRJkiTpD3L2vDVnZ2sURcFhVTm5uYqiY+65bIz+GhJv96ZenPFMpsRuR/vlYrTLlqG4XAijEdfg+1HT0kCr9QQgdpedFQUrWJK3BLuwo0FDz7Ce3B9zPz5an9pz1ggX9Y4vdfersZcDUBnVmYLWz2Dzd49MrQmYaubDOVJkY/qOEnbnVgHgZ9Ty5O0NebhLQ7wNdR9a1H0NJEmSJOkGd6FsDbhniC/NcJGxuQqnVYAC0S2MxLXzRlP9lNZoNCi7d6OfNh2loMB9zLZtcT3yMISGcnaOZHfFbmZlzSLP5u5Y3MyvGSPjRpLgk3BmGYbqvjW++T8TtftDvCrcaw9aAxqQ1+oZLFGpns7CZ/cByqlwMGtnKRtPmgDQaxWGd4zjmbuaUM/X+DvewcsjgxtJkiRJ+h3VZGtqlk+w2+2ePi7WShcnf6iiNNPdV8W7nobErj74h+s8o5tEaRn62bPRbt4MgAgOxjlqJKJ9e5SzOuwW2gqZkz2HbeXbAAjSBZEem07n4M7nzDtjNGURsfvfBOSe6VdTmPwYpYnufjXirIBGo9FQZnWxYE8ZXx8ux6m6Mzn9Wkbwl15JxIVce7P4y+BGkiRJkn4HZ2drKioqsNlsOJ3OWksnnNpShcuBZ+mEmNbGM0snqCrab9ejmzcPxWJBKAqu3r1QhwwBb2/AnYFxqA5WFKxgaf5STxNUr/BeDIoc5GmCqjmnzmkm7MBMgo99jka456spThxEYfIjqIaAWp2LhRDYXIIlB8r4fF85Foc74OnUsB6v9EkiJbZeXd7ei5LBjSRJkiRdZb/M1thsNsCdBakqc3JiUxUVue5mKb9wLYm3u5dOgOomo9NZ6KdNQ3O4usNwgwa4HnsUtWFDqgsBsKdyD7OyZ5FvywegmW8zRsWPIs47rlaHYdXlIPjkciL2/w+drQyAyqhO5LV8GntA/XPmq3Gpgm+OVzJ7VynFFnc9kyL8eCmtGV2b/baFi/8IMriRJEmSpKtEVVUsFgvl5eW1sjUAQhVk76kia7vNvXSCFuLaexGVYkTRVAcidjv6JUtrdxgeMhi1d2/QatFUNy8V2guZk3VWE5Q+iPSYdDrV6wRQK7Dxzt9G9J5/413uXivP6l+f/NZjMEXe6g6kqsurqooQgm05VmbsKOVUmXsEVHSgkRd6NGFgmzg0dTgC6nLI4EaSJEmSroILZWsAqkpVjn9nwVzobtoJiHYvdGn0P7MelGbvPvQzpqPJc2dhXG3b4hw1CkKrZ36vaYIqXMHSvPM3QQGeJiWDOYeovZMJyN4AgFPvT2HyoxQ16I9GZ0Cj0Xg6C6uqytFiG9N3lLInz+quo5eOP3VtyMjbGuClv77CheurtpIkSZJ0jRFCYDabPdmaqqoqz0gooULObjs5u2wIFbR6iO/oRUSS0dPJV6moQD93Lrrvf3DvExyMY+QIRIcOnnMoisLeir18mv3pmVFQvs0YETuCBN+EWvVR7GbCD88i9OhCNKrDPV9Nw+p1oIyB1HRBrgls8kzO6hFQZgAMWoWHbo3n6buaEORj4Hp09eZFlq4ZmzdvRlEUevfufd739+zZw6BBgwgJCcHLy4vk5GQmTZrkSZ1eayZPnuxZzqBt27Zsqp5i/Hzeffdd2rdvj7+/P+Hh4QwYMIDD1W3WNerXr+/pYHf2P0899ZSnzJQpU2jZsiUBAQEEBASQmprKypUrf7drlCTp+mS32ykuLqagoIDi4mLMZrNnWQRzkcq+JWayd7gDm3rxOloNDiAiyehpDtJu2IDXX8ah+/4HhKLg7NUL26R/oLZv7xmuXeIo4YOMD/j7ib+TZ8sjSBfEU/Wf4tUmrxLvE3+mMkIl6OQKmqwZSvjhOWhUB6aI9hzv8Sm5t4zFaXAvWVCTKTLZBf/bVsITS7PYeNKMAtzTMoJ1L3Tlr/1SrtvABq6BzM3kyZOZNGkSubm5JCcn869//YsuXbr86n4//PADXbt2JSUlhV27dv3+Fb2OTJ8+naFDh7Jo0SIyMzOJjz/z4d+4cSNpaWkMHDiQpUuXEhYWxpYtWxg3bhybNm1iyZIlV3UtkN9q4cKFPPfcc0yePJnOnTszdepU0tLSOHDgQK3rqrFx40aeeuop2rdvj9PpZPz48fTs2ZMDBw7gWz0d+datWz2/qsC9EGiPHj24//77PdtiY2P529/+RqNGjQD49NNP6d+/Pzt37iQ5Ofl3vmpJkq5158vW1IyEUp2C7B12cvfZ3Qtdeik06ORNcEOd5/tVk5uLftp0tAcPAqAmxON87DHUxETAnalxqk6+zv+axfmLsatnJuIbFDkIX51vrbr4luwjavcH+JQeAsDmF0tey6epjLrNs75UzQ85m1Nl2eEKPttXjtl+ZgTUy2lJtIi7dkdAXY46XThz4cKFDB8+vNaD65NPPrngg6tGeXk5bdq0oVGjRuTn519WcHOjL5xpNpuJjIxk3bp1vP7666SmpvLaa68B7omiGjduTKdOnZgzZ06t/Q4cOEDr1q2ZMmUKjzzySF1U/bw6duxImzZtmDJlimdbUlISAwYM4N133/3V/QsLCwkPD2fjxo3cfvvt5y3z3HPPsXz5co4ePXrOXBBnCw4OZtKkSRe9PzfCZ0iSpItzOByeoKayshK73e55z5Tv7ltjq3A/WkMSddRP9Ubnpbj7uNhsGJYvR7f0KxSnE2E04rzvXlxpaSi6M/mG/ZX7mZU9ixxbDuBeC2pk7Ejivd3PxpogSWcpIGrfFIJOrwXApfOhIGkUxYn3gs5Y6ztNFYINGWZm7SqjsHoNqCbhvryc1oxuSZG/4x27Oq6bhTPff/99HnnkER599FEA/vWvf7F69WqmTJly0QfXE088wbBhw9BqtSxZsuR3raMQgipn1e96jgvx1nlf9GF7PgsXLiQyMpIOHTqQnp7Oq6++yquvvoqiKPz8889kZGSwePHic/Zr3rw5ffr0YeHChb9LcPPOO+/wzjvvXLTMypUra2Xt7HY727dv56WXXqpVrmfPnmyunszq15SXu6cSDw4OPu/7drudOXPmMHbs2Avea5fLxeeff47ZbCY1NfWSzitJ0o1HCIHFYqGsrIzKykosFounOd/lEGRts1Nw0L10gt5HoUFnL4Lrn2naUQ4cxHv6dDQ57oDF1aoVzkcegfAwqF7WoNRRyvzc+Wwp2wJAgC6AodFDuT3kFz/OnFbCjswn/MhcNC4rAoWS+n0pSHkC1TsEpbq+NU1bO3MsTN9ZxomSM2tAje3RmPva1e0aUL+XOgturvTBNWPGDI4fP86cOXOYOHHir57HZrPV6rFeUVFxWfWsclbRcV7Hy9rnavlp2E/46H0ua59p06aRnp4OwIABA3jiiSdYt24d3bt3JyPDPb1248aNz7tvkyZNWLp06WWdb/ny5bzwwguoqsqLL77oCVR/afTo0QwePPiix4qJian1uqioCJfLRURE7TkVIiIiyMvL+9W6CSEYO3Yst912GykpKects2TJEsrKyhg5cuQ57+3du5fU1FSsVit+fn4sXryY5s2b/+p5JUm68TidTk+2pqKiola2piLbRcb3Vs9Cl2FN9cS1N6L3co9a0lgs6OfPR7d+AwAiMBDHiIdwdeyIRqsFwKE6WFeyji/zvsSqWlFQ6B7SnXuj7sVP53dmgUsgMHsDUfsmY7C4vwfNIS3Jbf0c1npN3RU6a4mFU2UOZuwsY3tO9RpQBi1P3N6AR29PvCbWgPq91NmVXcmD6+jRo7z00kts2rQJne7Sqv7uu+/y5ptv/ub6Xg8OHz7M5s2bmTFjBgB+fn7079+f6dOn0717d08ar6SkBB+fc4Om0tLSX031nc3pdDJ27FjWr19PQEAAbdq0YdCgQefNkgQHB18we/JrfplRqfkl8muefvpp9uzZw/fff3/BMtOmTSMtLY3o6Ohz3mvatCm7du2irKyMRYsWMWLECDZu3CgDHEm6idRka2oCG7PZ7Omz57QJTv9so+ioO3tj9FNoeLsPAdFa9zwzqor2xy0Y58xBqf5h7bzzThwPPIDi7+cJQg6bDjMzeyZZ1iwAGvk0YkTsCBr4NKhVF+/yY0Tv+RC/ol0A2L3DyWvxFOWxd7r71VRnajQaDSVVLubsLuOb4yZUAVqNwrB2MTzXsxkhftfOGlC/lzoP2y71weVyuRg2bBhvvvkmTZo0ueTjv/zyy4wdO9bzuqKigri4uEve31vnzU/Dfrrk8leTt877sspPmzaN9u3b17o/6enp3HvvvZSWlpKamoper2fZsmU8+eSTtfZ1uVysWbOGQYMGebalpaWRlJTE5s2bKSsrY/bs2bz11lvs3r2b8ePHk5KSQnJysifj0qdPH1avXs3QoUPPqduVNEuFhoai1WrPCXYLCgrOCYp/6ZlnnuGrr77iu+++IzY29rxlTp06xTfffMOXX3553vcNBoOnQ3G7du3YunUrH3zwAVOnTr3ouSVJujE4nU4qKipqTchX84wqy3Ry8gcbjip3gBKRbCC2rQGdQeOeZyYvD6+ZM9Hu2QuAGhON45FHUZs19cwvU+GsYEHeAn4odQ8B99P6MSR6CF2Du6LVaD310NrKiDzwCcEZy1BQUbVGCpqkU9RkGKrW6F5Us/q5aba7+HJvGYsPVmBzuuvWMymMl/ok0TDM/4+8fXWqzoKby31wVVZWsm3bNnbu3MnTTz8N4JlNUafTsWbNGu68885z9jMajRiNVx6lKopy2U1DdcHpdDJr1qxzmvl69eqFv78/c+fO5emnn2bMmDFMnDiR/v3718pW/POf/6S4uJjnn3/es23fvn0MGTKE999/n4ceeogXX3yRZcuWcfToUZ588kleeOGFWk1JsbGxZGdnn7d+V9IsZTAYaNu2LWvXrmXgwIGe7WvXrqV///7nPYYQgmeeeYbFixezYcMGGjRocN5y4G7iDA8Pp2/fvhet19nHPruJU5KkG5MQgqqqKsrKyjzZmpqRUE4rZG6xUpLhztZ4BWpoeLsXvmHVAYbTiXbVavRffolityP0ehz978HRty+a6meRKlS+Kf6GRXmLsKgWFBTuCL6D+6Pux1/nf2Z2YdVJaMYSIg5OR+dwr8JdFnsneS3+hNM3yp2lqS7rdKmsPW5m3p5ySq3uzFLr2ADG902ifYPQurmRdajOgpvLfXAFBASwd+/eWtsmT57Mt99+yxdffHHRh9jNYPny5eTn55OSksK+fftqvdelSxemTZvGyJEjGTNmDFu2bKFbt27Mnz+fNm3aMGnSJMaPH8/UqVMxGAy4XC5MJhMGg8HTF8XLy4tnn30WX19fjEYjgYGBnG+g3YWai660WWrs2LEMHz6cdu3akZqayscff0xmZiajR4/2lPnoo49YvHgx69at46mnnmLevHksXboUf39/T/AcGBiIt/eZTJiqqsyYMYMRI0act4nzlVdeIS0tjbi4OCorK1mwYAEbNmxg1apVl30NkiRdPy6UrRFCUJLhJHOLDacVUCCqhYHo1np0BneWRXviBPpPpqHNzATA1TwJxyOPQHQ0murvy+OW48zKmcXJqpMA1Peuz8jYkST6JHrqIITAv3AbMXv+jVelu1xVYGNyWj2LJax1TSFPEPRzVhUzd5VxutzdmTm+nhfjejelb8uYyx6UcqOo02apX3twvfzyy2RnZzNr1iw0Gs05nULDw8Px8vK6YGfRm8m0adMA6NGjxwXLDBs2jGXLlnlef/jhh8ycOZNx48YB8PDDDwOQkZFBdnY27du395Tdu3cvEyZM8Px3SkoKMTExtTI1WVlZdOx4dTtfDxkyhOLiYiZMmEBubi4pKSmsWLGChIQzM3IWFRVx/PhxAM+Q8TvuuKPWcWbMmFGr0/A333xDZmam55p/KT8/n+HDh5Obm0tgYCAtW7Zk1apVF72/kiRdvy6UrQGwW1QyN9spO+3OiHgHa2jYxQu/MJ37R15VFYZFi9CtXoMiBMLPD/vQoah3dPX0hbGoFj7L/YwNJRsQCHw0PtwXdR93hdxVqwnKaM4hau9HBOa6+wo6DYHkJT9OSf2+oGg9o6AAjpXYmbGjjD357uUSgrx1PN0tkeGpDTDqtdzM6jS4+bUHV25uLpnVEbB0cWcHLZfrfBmY1atX06JFC8/7+fn5REa650HYt28fLVq0oEOHDuzbt4/s7GwCAgJYsWKFZ06dq+lPf/oTf/rTny74/htvvMEbb7xxwWs5n549e160bE2wKEnSjc/lclFeXl4rW1OzNEHxMRenf7bhsoOigahWBqJbGdDq3P1mdLt2Yfx0FpriYgCcnTphfzAdJSio+hiC70u/57O8z6h0VQJwW73beCDqAQL1gZ7si8ZhIeLoHMKOfeZZMqGo4UAKkh7GZXD3lamZhK/I4mLWrjLWZ7iXS9BrFUbcGs8zdzUh8DqeVfhqqvMOxRd7cM2cOfOi+579UJOurv3799O9e3cATp48Sf369T3v7du3jwEDBqDT6Xjvvffo1q0bqqoybtw4QkJC6qjGkiRJl0cIgdVqpbS01JOtsdvtaDQa7CaVU5vtVOS4gxzfUA31uxjxqVedESktxXv2HHQ//wyAGhaGfdRIROvWnlFQWbYsZuXM4qjlKAAxxhhGxIwgyT/pTB1UF/VOryX6wFT0VneAVBnenpyWz2D1r+/uLFxd1uJQ+WJ/BUsPVWJ3uc/RNyWCF9OaER/i9zvfretLnc5QXBdu9BmKpbolP0OSdH1wuVxUVFR4mqFqsjVCCIqOuMjaakd1gqKF6Fv0RLcwomgUUFV0GzdiXLAQxWJBaDQ409KwDxyAxscHVVWxCRtLCpawpmgNKipGjZGBEQPpEdIDvUbv6QfjXXqQ2D3/xrd0PwA232hyWzxDRVRnFM2Z1cJVAauOmZi/t5xyqzvYahcfyPi+zbkl4cqm2LgeXTczFEuSJEnSH6kmW1NWVkZ5ebknW6MoCrYKlZOb7Zjy3AGEX7iG+rcZ8Q5yz1uj5OTgNX0G2urFeF0NGmB/5GFEgwYouAOmbZXbmJ87n1JnKQDtA9vzYPSD1NOfWbNJW1VM9MFPCM5ciYLApfUmv+mDFCbeDzovT1OVEIJtOVZm7Cwnq8LdWTgh2JuX0prROyXqpu0sfClkcCNJkiTdFFwuF5WVlZ7Axmq1eoKIgoNOcnY4UJ2g0UFsWwPhSXr3lMBOJ/rlyzF8tcy9HpTBgP2++3D26ulZDyrfls/s3NnsM7lHq4YbwhkePZzWga0950B1EnFyCZGHZqJ1uvvLlMT1JC9lNE7vME9zFsDxYhszd1ewO+9MZ+ExdzbiwdT6GHQ3d2fhSyGDG0mSJOmGd3a2xmQyebI11nKVkz/YMRe4szX+kRrq3+aFV4B73hrN4cMYZ8xAm+1eD8rZsiX2USNRQ0NRFAW7y86K4hV8Xfg1DuFAr+jpG9aXvmF9MWgMnqalgMJtxOz9CG/TKQAsQU3JbjkGS0gLTwZGURSKLU5m76lg/QkzAjBUdxZ+unsTAr1lZ+FLJYMbSZIk6YalqmqtvjVVVVXuTIoqyD/oJGenA+ECjR5i2+kJbaJDo1EQZjNeX3yBft237uMEBGAf/iCuW28FRUGjKOyp3MOc3DkU2AsASPFL4aGYh4gwRHialvSmbOL2TyEwzz2022EIcg/tTkhzD+2uDmyqHCqLDlSw9JAJm6ezcDgvpiXJzsJXQAY3kiRJ0g3JZrNRWlpaK1sDYC0XnPzejqXIna0JiNaS0NmAwdc91Fq3fTtes2ejKS0DwHF7F6wPPIDi7549uNRRyvy8+Wyt2ApAkC6IYVHD6BDY4Uw/GEcV0cfmE35sARrV7h7a3WAgeUmjUA3+7oyOELhUwbcnLczdU0FplXsenVtiA/jr3c1pW1+OPr1SMriRJEmSbiiqqlJZWUlpaSmVlZVYLBaEELicLgoPCnJ3ORAqaPUQ18FASGOdu8NwaSlec+ag37bdfZyICGwPj8KZlISiKLiEi3XF61hSuMSzcnePkB4MDB+Il8Y9OtK9avd6Yg/8F0OVO6NTGdaWrBZjsAXUd1ewuqlqd76NGTvLOVnm7iwcF+TFi2k398zCV4sMbiRJkqQbhs1mo6ysjLKyslrZGkuJi1M/OKgqcQcWgbEa4lMNGHw1KEJg2LgR48LP3MO7tVrsfdKw9++PYjSiURSOW47zac6nnLadBiDRO5ERMSNI8D4zW7qx/Djx+z7Cv3iXuy4+kWQnP0VFdBeonoAP4HS5g5m7ytmW4+4s7G/U8tQdiYy8rQFeevlYvhrkXZQkSZKue6qqYjKZag3xFkLgdLgo3K+St9fpztYYILaDnpBEd7ZGm5eH1/QZ6I4cAcDVsCHWh0chEhJQALPLzBcFX/Bd6XcIBL5aX+4Pv5/bg29Ho2gA0NoriTo8g7CMpe5VuzUG8hoPo6DxUITWvVimApRVOVmwv5LVx8yoArQahWHtY3i+RzOC/a58gWfpXDK4kSRJkq5rdrudsrIySktLMZlMWK1WNBoN5iIXpzY7sJa6szVB8VoSUg3ovN2rdxtXrMT41Vfu4d1GI7b77sPZswdUT6C3uXwzn+WftWxC0G0MjhyMv7Z6OQRUQk6tJPrgJ+jt5QCURnclJ+VPOHwiq8uAwyVYftTE5/srsDjcdbmzSQiv3J1Mo3D/P/hu3RxkcCNJkiRdl4QQmM1mSkpKKC8vx2Kx4HK5UF2C3F128ve5QIDWCHEd9dSrr0WjUdAeO473jBloqxf+dbRsiW3kCNSQEBRFIdeWw+zc2Ry2uCfrq1k2oYlPE8+5fUsPELf3Q3zL3RmfKv8EslKewRTeztP8JIRg82krs/aUk29ydxZuFuHLX/s257Ym4X/krbrpaOq6AtLVt3nzZhRFoXfv3ud9f8+ePQwaNIiQkBC8vLxITk5m0qRJnhVwrzWTJ0/2LGfQtm1bNm3adNHyU6ZMoWXLlgQEBBAQEEBqaiorV66sVeaNN97wLEJX80/NwqCXU0aSpLrhcDgoKioiJyeHwsJCKioqUFUVS5HKkRUO8ve6A5ugBC3JA7zdgY3Nhtfcufi+/Tba7GxUf38so0dTNfZ5CAvDLux8WfAlr594ncOWwxgUA/eF38frDV+nsXdjFEVBbyul/q6/0+z7p/EtP4JL58vp5Kc42PWTWoHNkWI7r3xbzKTNJeSbXIT5GfjbwGRWPNtVBjZ/AJm5uQFNnz6doUOHsmjRIjIzM4mPj/e8t3HjRtLS0hg4cCBLly4lLCyMLVu2MG7cODZt2sSSJUvQaK6dmHfhwoU899xzTJ48mc6dOzN16lTS0tI4cOBAres6W2xsLH/7299o1KgRAJ9++in9+/dn586dJCcne8olJyfzzTffeF5rtefO+nkpZSRJ+uOcna2pWezS6XTicqrk7HVSsN8d1Oi8ILajnpAGegC0u/bgM3u2Z/Vu+22dsQ0divDzQ1EUdlXsYl7+PIocRQC09m9NemQ6IXr3cGwNKmHHPif6yCy0TgsARfFp5DZ/HIchyFO3QrOTuXsr2XiqCgAvnYZHb0vgyW6N8TXq/8hbdVOTwc0Nxmw2s3DhQtatW0dpaSkzZ87ktddeA9xTj48aNYpBgwYxZ84czz5Nmzalffv2tG7dmhkzZvDII4/UVfXP8f777/PII4/w6KOPAvCvf/2L1atXM2XKFN59993z7tOvX79ar99++22mTJnCli1bagU3Op3uVzMxl1JGkqQ/hsPhoLy8nJKSEkwmk2dCPkux4PRmJ9Zyd3+WevW1xHbQoffWQHk53vPmY/jpJ8C9enfViBG4WqQAUOIoYWHBQrZXuod/B+uCSY9Kp01AG8A9a7BvwTYS9n+EtykTAHNgU063HIOlXnMANBoNVQ6VLw+aWHrYhN0lUID+rSIZ1zuJ6Ho+f+RtkpDBzQ1n4cKFREZG0qFDB9LT03n11Vd59dVXURSFn3/+mYyMDBYvXnzOfs2bN6dPnz4sXLjwdwlu3nnnHd55552Lllm5ciVdunTxvLbb7Wzfvp2XXnqpVrmePXuyefPmSzqvy+Xi888/x2w2k5qaWuu9o0ePEh0djdFopGPHjrzzzjs0bNjwsstIkvT7EkJQVVXl6VtjMpk82Zr8PSoFB87O1uiol6ADITBs/hGv+fPRmEwIRcHeqyfWgQPBaEQVLr4t/ZYlRUuwqTY0aOgZ0pN7wu7BW+vtboKy5BN3YAr1cr8DwGEIJLvZo5Qk9IHqkVIChW9OmN2T8FWv2N02PpBX725O6/ibZ8Xua40Mbn6FEAJRVVUn51a8vS97Iqdp06aRnp4OwIABA3jiiSdYt24d3bt3JyMjA4DGjRufd98mTZqwdOnSyzrf8uXLeeGFF1BVlRdffNGTYfml0aNHM3jw4IseKyYmptbroqIiXC4XERERtbZHRESQl5d30WPt3buX1NRUrFYrfn5+LF68mObNm3ve79ixI7NmzaJJkybk5+czceJEOnXqxP79+wkJCbnkMpIk/b5cLhfl5eWUlpZ6lk9QVRVzkcrpzU5sFe5y9epriO2gR++tQVNUhPens9Dvcy9i6YqLo+rhUbgaNEBRFE5UnWB23uxac9YMjxxOgk8CqqqC00ZkxhdEHZuLxmVDoKGwQX9ymoxENQYA7mfDvgIbM/eYyCh1T8IXG+TFy2nN6NMyWk7CV8dkcPMrRFUVh9u0rZNzN92xHcXn0tOZhw8fZvPmzcyYMQMAPz8/+vfvz/Tp0+nevTsBAe7/KUtKSvA5z3FLS0s9ZS6F0+lk7NixrF+/noCAANq0acOgQYMIDj7310pwcPB5t1+KX35JCCF+9YujadOm7Nq1i7KyMhYtWsSIESPYuHGjJ8BJS0vzlG3RogWpqakkJiby6aefMnbs2EsuI0nS70MIgdVqpaSkhLKyMiorKz3ZmoK94vzZGlXFuGYNXou+RLHbETodtgH9sfXuDTodVWoVXxZ+ycayjQgEPhof7g+/ny71uqDVuPvTBRX8RPyB/+BlyQWgMrglWS3GYAlo6Pneya10MmtPJT9luyfh8zVoeeqOhjzcpaGchO8aIf8KN5Bp06bRvn17mjQ5M1wxPT2de++9l9LSUlJTU9Hr9Sxbtownn3yy1r4ul4s1a9YwaNAgz7a0tDSSkpLYvHkzZWVlzJ49m7feeovdu3czfvx4UlJSSE5O9mRc+vTpw+rVqxk6dOg5dbuSZqnQ0FC0Wu05WZqCgoJzsjm/ZDAYPB2K27Vrx9atW/nggw+YOnXqecv7+vrSokULjh49esFjXkoZSZJ+O5fLRUVFhafTcM3yCaZCF1k/us5kaxpoiGmvw+CtRXM6C58ZM9BVZ6idTZtQNWoUamQkQgh+rviJzwo+o8Ll3rlTYCfuD7+fAF0AGo0GgymL+AOTCSpw982xG0PITn6S4qg70Gi17gn97CpfHDTx9VEzThU0CgxuG8OfezUj1N+rLm6VdAEyuPkVirc3TXdsr7NzXyqn08msWbPO6Z/Sq1cv/P39mTt3Lk8//TRjxoxh4sSJ9O/fn+joaE+5f/7znxQXF/P88897tu3bt48hQ4bw/vvv89BDD/Hiiy+ybNkyjh49ypNPPskLL7xQqykpNjaW7Op5I37pSpqlDAYDbdu2Ze3atQwcONCzfe3atfTv3//Xb8pZhBDYbLYLvm+z2Th48GCt4OpKykiS9NvUZGvKy8spLy+v1bem8KDqztZ4Q2wHHUHxWnA4MC5aitfKlSguF8Lbm6rB9+Po2hVFq6XAls/c/LkcsBwAINIQyYMRD9LMt5l7hmLVRtSR+USe+AyN6kBVdBQ0vI+cxumoOh80Gg0uVbD2hIUF+01U2Nz9ajo3rMer/ZJpFhVYl7dLugAZ3PwKRVEuq2morixfvpz8/HxSUlLYV93OXKNLly5MmzaNkSNHMmbMGLZs2UK3bt2YP38+bdq0YdKkSYwfP56pU6diMBhwuVyYTCYMBgMjR44EwMvLi2effRZfX1+MRiOBgYHuVW1/4ULNRVfaLDV27FiGDx9Ou3btSE1N5eOPPyYzM5PRo0d7ynz00UcsXryYdevWAfDKK6+QlpZGXFwclZWVLFiwgA0bNrBq1SrPPn/+85/p168f8fHxFBQUMHHiRCoqKhgxYsRllZEk6epQVZWKiopaq3gLITAXqedka6LbadF7adAdO4bvzE/R5rqbkOxtbsE6fDiiXj0cqoPVhSv4uuRrnMKJTtHRN6QvvYN7Y9AaQAiC874n7uAUjNULXJaHtuV0ytPY/N3rRSnAztwqPt1jIrPcPQ9YgxBvxvdJonty1B9+j6RLJ4ObG8S0adMA6NGjxwXLDBs2jGXLlnlef/jhh8ycOZNx48YB8PDDDwOQkZFBdnY27du395Tdu3cvEyZM8Px3SkoKMTExtTI1WVlZdOzY8epdFDBkyBCKi4uZMGECubm5pKSksGLFChISzixWV1RUxPHjxz2v8/PzGT58OLm5uQQGBtKyZUtWrVpV695kZWUxdOhQioqKCAsL49Zbb2XLli21jnspZSRJ+u1sNhulpaWewMbpdOKwOyncC4WHVE/fmrhbdQTGaaHKis/cRRjXb0ARAjUgAMuD6TjbtUPRaDhoOsi8wnnk2d1N2sm+yQyLGEaEwd2c7WU6TcKB/xBY5M7K27zDOd38T5RHdUHgDmpyqvvVbM1xZ3wDvXSMuTOR4Z0aYNDJ+a6udYo438/vG1hFRQWBgYGUl5ef03nWarWSkZHhmQ33ZjZ16lSKiooYP348QggSExM5ceIEAK+99hqJiYmkp6eTlJTEhg0bPB2Kt2zZclOPJJKfIUm6dKqqUllZSWlpKWVlZVgsFpxOJ5YiQdaW82drtLt34z9nLpqSEgBst91G1ZDB4OdHpauSLwq/4MeKHwEI0AbwQMQDtPdvj0ajQeOsIvrYXCIzFqERTlSNnryGg8ltNBRV64WiKFic8PkBEyuOmnGdtbjl2J7NqOcrF7esSxd7fv+SzNxI57V//366d+8OwMmTJ6lfv77nvX379jFgwAB0Oh3vvfce3bp1Q1VVxo0bd1MHNpIkXbqaxS5r+tfY7Xb3Ct77ONO3xgtib9URGKtBqazEd9ZCjNWT8bnCwqgaOQJn8+YIIfixYjOfF3yOWTWjoNA1qCv3ht+Lt8YbBQjO3UjcwakYrYUAlIV35FTSkzj84wBQVcE3GVUs2G+isrpfze2NgnmtXzKNIi59FKl0bZCZm7PIX93SbyU/Q5J0cUIITCYTJSUllJaWYjab3f38Cl3k/CQ82ZqgBgrRbbXojQqGn3/Gd/4Cz2R8tp49sPTvj8bbmzx7HrPzZ3O0yj2KMdYYy4MRD9LIxz1a0tucScL+jwgs3gWA1TuSzOSnqIjshBACjUbDzlwrs/ae6VfTMNSHv/ZN4s4kOTv5tURmbiRJkqRrjsPhqJWtsdls1dkaQeFB4cnWxHTUEhirQVtaiu/HczDs2QuAMyYG88gRqImJOFx2VhUtZVXJKly4MCgG7gm9h7vq3YVO0aFxWog5NpfIk1+iES5UjZ7chg+QkzgERe8eiZprcjFrbznbzupX8+ydiTzUuSE67bWzxp50+WRwI0mSJP2uhBBYLBaKioooKyvDbDbjcDioKoGsH9Uz2Zr6CtHttOj0Aq8NG/FdtAjFakVotVj79cPSuxeKXs9B8wHmF86nwOEe5dTCtwXDIoYRqg8FIQjJ3UDCof9hsLkXwSwNv5XM5n/C5hOFoiju+WoOmVl5zIJTPdOv5oVeSQT5GOrqNklXkQxuJEmSpN+N0+mkrKyM4uJiKisrsVgsOOxOig8qFB44k62Jbq8hKF6LJi8f/9mz0B9xNzM5EhMxjxyBKyoKk2rii/w5/FTp7ncTpAtiSOgQ2ga0RVEUfEyZ7lFQJbsAsPpEkdn8KcojbkUIgSoE32ZYWXjATHl1v5oujYJ57e5kGkfKfjU3EhncSJIkSVddzfIJxcXFFBcXY7FYsNvtVJUIsraArXoF78AEhei2GvQGgfeq1fh89RWKw4EwGLAMGoTtrjsRGoXNFZtZVLQIi2pBQeGOwDvoH9IfX70vGqeF2OPzzmqCMpCT+AC5DYeAzj3CaX+hnU/3mjlZdma+mr/2TeKu5nK+mhuRDG4kSZKkq6pmscvi4mLKy8upqqrCbnVQclihYL87W6M1Qkx7DUEJWrSnT+M/81N0mZkA2JObYx4+HDU0lFxHLvMK5nHMegyAOGMcwyOG08C7AUJVz9MElcqp5k9i845EURQKzC7m7DWxJdvdr8bfqGXMnYmM6NxQzldzA5PBjSRJknTV1GRrysrKPEO8q0oFOT+BtcydrQmIU4hpr0GrceCzZDneK1eiqCqqjw+WIYOxdeqEQzhZVbKM1aWrz3QYDrmHO4PuRKfR4WXKpP6B/xBU0wTlHcWp5n+iLLwjiqJgcwoWHzaz/KgFR/U6UEPaxvDn3kmE+Mn5am50MriRJEmSfrOa5ROKioqoqKjAZDLhdDgpPqRQsK86W2OA6PYKgfEadMdPEDB7NrrqpRNsbdpgGjYUpV49DlsOMa9wnqfDcEvflgwNH0qwLhidaifmyCyiTn5ZPRGfgZyGD5DTcDBCa0AVgh9O25i7z0yp1d2vpmP9IF7vl0zzmKC6uj3SH0wGN5IkSdJvYrfbPSOhysvLsVqt2CsUsraAtdSdrfGPhZj2WnSKDb/PluL97XrP0gmmYUOxt22LWTXzRd4MfjK5OwwHagMZEjaENn5tUIB6ed/T8MjHnon4SsM6cKr5U9h9oxFCcLTEwad7LRwtcQAQG2RkfN/m9E6JuuC6d9KNSQY3kiRJ0hURQlBZWUlxcTGlpaVUVlaiulSKDgkK9wmE6s7WRLZRCKqvYDh4gIA5c9EWFwNgTU3FPGQwwteXLZVbWFS86MwMw4Fd6R/s7jDsZc6m/sHJ1CuuXgvKK4KMpNGURXRCURRKq1zMP2Bh4ykrAD56DU92bchjXRPx0svH3M1I/tUlSZKky+ZwOCgpKfFMyGc2m3GYFLJ/Aqt72Sf8oiGmgwaDqMJvziK8v/8BAFdwMJXDH8SZkkKho5B5OZ9w2HoYgBhDDOnh6SR6J6I4rcQe/ZSYjM/dTVCKntyG95PVYDBC541ThRXHq/jysAWr050hGtAqkpfSkogM8qmT+yJdG2RwI0mSJF0yIQRms9mTrSkvL8fldFFyRKFwLwgVNHqIuAWCG2ow7t6N//wFaMvKALDccQdV9w7CptewrnQlK8tW4hRO9IqevvX60jO4J1pFS73Cn2hw6L94VblX9i4LacPJ5k9h9Y1FCMH2XDtz9lnIM7sAaBHtz5v3JNOmvlzfTgI5v/QNaPPmzSiKQu/evc/7/p49exg0aBAhISF4eXmRnJzMpEmTcDqdf3BNL83kyZM9azW1bduWTZs2XfK+7777Loqi8Nxzz9XaPmXKFFq2bElAQAABAQGkpqaycuXKc/bPzs7mwQcfJCQkBB8fH1q3bs327dt/6yVJ0nXJ6XRSXFxMVlYWOTk5lJWVUVXm4uR6KNjtDmx8I6FRmkJouIXAT6YRNOW/aMvKcEZEUPaXv2BJH8Yxsvl7zt9ZVroMp3DS3Ls5r8W/Ru/g3nhXFdJs55sk7XwDr6o8bMZQDrd8hYNt38bqG0tWhZN3f6zk/36qJM/sItRXzz8GJbP06S4ysJE8ZObmBjR9+nSGDh3KokWLyMzMJD4+3vPexo0bSUtLY+DAgSxdupSwsDC2bNnCuHHj2LRpE0uWLEGjuXZi3oULF/Lcc88xefJkOnfuzNSpU0lLS+PAgQO1rut8tm7dyscff0zLli3PeS82Npa//e1vNGrkXlzv008/pX///uzcuZPk5GQASktL6dy5M926dWPlypWEh4dz/PhxgoKCrvp1StK1rGZCvsLCQkpKSqioqMDpdFJyVFCwR0G4QKOD8NYQkqhg3LqNgM8+8yx0WdWrJ6a+fbHqVZYUzuP7yu8B8NP4cX/o/bT3a49GOIk7+Rkxx+ejVW2oipbchIFkJaaj6ryxOASLDltYdaIKVYBeqzAqNZ4x3Zvi56Wv2xskXXPkquBnuRFWdDabzURGRrJu3Tpef/11UlNTee211wD3xFqNGzemU6dOzJkzp9Z+Bw4coHXr1kyZMoVHHnmkLqp+Xh07dqRNmzZMmTLFsy0pKYkBAwbw7rvvXnA/k8lEmzZtmDx5MhMnTqR169b861//uui5goODmTRpkuf6X3rpJX744YfLyhTdCJ8hSTqbqqqUlZVRVFRESUkJVVVVWCtV8raCpdA9AsknHGI6KhjtZQTMX4DXnj2Ae6HLiocewlk/gZ3mnXxe8jkVLvdCUp38OzEoZBB+Oj8Ci3fR8NBkfCxZAJTXa8GJpKeo8ktAFYINpx18drCKiuolE+5sEsKr/ZJpEOZfB3dEqityVfCrSAiB067Wybl1Bs1lD19cuHAhkZGRdOjQgfT0dF599VVeffVVFEXh559/JiMjg8WLF5+zX/PmzenTpw8LFy78XYKbd955h3feeeeiZVauXEmXLl08r+12O9u3b+ell16qVa5nz55s3rz5osd66qmn6Nu3L927d2fixIkXLetyufj8888xm82kpqZ6tn/11Vf06tWL+++/n40bNxITE8Of/vQnHnvssYseT5JuFDUT8hUVFVFZWYnNZqfshCB/NwingqKF8JYQ2kTB68cf8f9iERqLBaHVYumThqlXL8o1ZhYWTGWvxb2yd7g+nPSwdBp7NcZoL6HBgY8Iy/8OALuhHiebPEJx9F2gKBwudjBrbxUZ5WeWTHi9X3PuaBZZZ/dEuj7I4OZXOO0qHz+7sU7O/fgHXdEbL2968GnTppGeng7AgAEDeOKJJ1i3bh3du3cnIyMDgMaNG5933yZNmrB06dLLOt/y5ct54YUXUFWVF198kUcfffS85UaPHs3gwYMveqyYmJhar4uKinC5XERERNTaHhERQV5e3gWPs2DBAnbs2MHWrVsver69e/eSmpqK1WrFz8+PxYsX07x5c8/7J06cYMqUKYwdO5ZXXnmFn3/+mTFjxmA0GnnooYcuemxJup7VTMhXWFhIWVkZFouFqkoneVvBnO/+weUdKojpoOBlKybw3wswHjgAgCMhgYoRD2GPimSTaRPLSpdhEza0aOkZ1JPeQb3RoyHm9FfEH5+NzlWFQENeXF9OJQ5HGAMosrhYcNDKD1nuJRP8jFrGdEtk5G1yyQTp0sjg5gZy+PBhNm/ezIwZMwDw8/Ojf//+TJ8+ne7du3vSeCUlJfj4nDtMsrS09FdTfWdzOp2MHTuW9evXExAQQJs2bRg0aBDBwcHnlA0ODj7v9kvxy+yVEOKCGa3Tp0/z7LPPsmbNml9tFmratCm7du2irKyMRYsWMWLECDZu3OgJcFRVpV27dp6M0y233ML+/fuZMmWKDG6kG5bdbvcsdumekM9G2UmVgl0KqkNB0QjCWkBIY/D5fhP+ixejsdkQOh3me/ph6d6dLFcu8/Pe55T9FACJxkQeCHmAGK8Y/MsP0ejQZPxMJwCoDGjCiebPYA5ohM2psupIFUuOWLG5BApwX5soxqU1J8xfNvNKl04GN79CZ9Dw+Add6+zcl2PatGm0b9+eJk2aeLalp6dz7733UlpaSmpqKnq9nmXLlvHkk0/W2tflcrFmzRoGDRrk2ZaWlkZSUhKbN2+mrKyM2bNn89Zbb7F7927Gjx9PSkoKycnJnoxLnz59WL16NUOHDj2nblfSLBUaGopWqz0nS1NQUHBONqfG9u3bKSgooG3btrWu7bvvvuOjjz7CZrOh1bp/+RkMBk+H4nbt2rF161Y++OADpk6dCkBUVFStTA64+/ssWrTootchSdejmgn5ioqKKC0txWQyUVXpIG+HgjnH/V3kVU8Q3VHBx1pA4AfzMB49CoA9sSGVDz2EJaweqyu+5pvyb1BR8VK8GBA8gNsCbsPgNFH/4L+JylkNgEPnx6lGIymIS0OgsCPPzpz9VeSb3d0AWsX482b/FFrHX9mPIunmJoObX6EoymU3DdUFp9PJrFmzzumf0qtXL/z9/Zk7dy5PP/00Y8aMYeLEifTv35/o6GhPuX/+858UFxfz/PPPe7bt27ePIUOG8P777/PQQw/x4osvsmzZMo4ePcqTTz7JCy+8UKspKTY2luzs7PPW70qapQwGA23btmXt2rUMHDjQs33t2rX079//vMe466672Lt3b61to0aNolmzZrz44ouewOZ8hBDYbDbP686dO3P48OFaZY4cOUJCQsJFr0OSrjc1E/LVLHhpsVioOC0o2KnBZVdAEYQ2F4Q2Bb+N6/H/6isUhwPVYMA8cCDm27twyHaEz3L/S5HTvTp3K59WDAkdQqDGn8jcdTQ4NgO9w92ZOD+6OxmJI3F5BZNjcjFnv5XdBe4lE0J99bzUuyn3touXSyZIV0wGNzeI5cuXk5+fT0pKCvv27av1XpcuXZg2bRojR45kzJgxbNmyhW7dujF//nzatGnDpEmTGD9+PFOnTsVgMOByuTCZTBgMBkaOHAmAl5cXzz77LL6+vhiNRgIDAznfQLsLfRldabPU2LFjGT58OO3atSM1NZWPP/6YzMxMRo8e7Snz0UcfsXjxYtatW4e/vz8pKSm1juHr60tISEit7a+88gppaWnExcVRWVnJggUL2LBhA6tWrfKUef755+nUqRPvvPMOgwcP5ueff+bjjz/m448/vuzrkKRrUc2EfDXZmvLycqpMdgp2aTBluX8IGAMFke0F/vYCgv45B0N13z1b0yZUDB9OZT1vFpfN96wHFaQNYnDIYFr7tca7MoPGh98msPwgAGbfBE4kPUV5UDIWh2DpgSpWnbDhEqDTVA/t7tEUfzm0W/qNZHBzg5g2bRoAPXr0uGCZYcOGsWzZMs/rDz/8kJkzZzJu3DgAHn74YQAyMjLIzs6mffv2nrJ79+5lwoQJnv9OSUkhJiamVqYmKyuLjh07Xr2LAoYMGUJxcTETJkwgNzeXlJQUVqxYUSt7UlRUxPHjxy/ruPn5+QwfPpzc3FwCAwNp2bIlq1atqnX/2rdvz+LFi3n55ZeZMGECDRo04F//+penw7YkXc9cLhelpaWewMZsNlOZI8jfocVldWdrQppCSFMnARu+xf/rFShOJ6qXFxWDBmLr0oWfTVtZnLMYk2pCQaGLfxfuCb4HH5egwdHpxJxegiJUXFovMhsOIyeuPy5Fy+YsBwsOWSmrXrX79kbBvH5PConhcmi3dHXIeW7OIucoOWPq1KkUFRUxfvx4hBAkJiZy4oS7A+Brr71GYmIi6enpJCUlsWHDBk+H4i1bthAScvPOEio/Q9L1oGZCvppmKKvFQeEehYqT7r41Bn9BRDuVQFsuQXPmYsjMdO/XvDllw4ZSHAiflXzGQas7IxOlj2JoyFASvRoSXPgjjY7+Dy+bu3mqKKwTx5s8ht0rjJPlLmYdsHG0xD20Oy7Ii9f6NadHclQd3AXpeiPnuZF+s/3799O9e3cATp48Sf369T3v7du3jwEDBqDT6Xjvvffo1q0bqqoybty4mzqwkaRr3S8n5DObzVTkuijYocVpUQBBUCNBWHMXgevW4L9qNYrLhertTfm991KV2pGNpu/4Ovdr7MKOFi1pQWncFXAXAfYSEvdMIKR4GwBWrwiONhlNaWg7zE74fJ+V9afsCMBbr+FPctVu6XckMzdnkb+6pd9Kfoaka5XdbqeoqMjTDFVlsVG0T6H8uLtvjc5HENHWRT1HLvVmz0Zf3eRsbZFC+dChZPlamF8yn0y7O4uTaExkWOgwwpUgErKXEX9yAVrVjqroyEoYxOn6g3EoRtafdvDFYRtmh/tR0zc5nPF3JxNdT67aLV0embmRJEmSgDNDvAsKCiguLqayshJzoUrBDi32SvcAgIAGKhHNnQSuW43/mjUoqorq60P54MGU3ZLCN+Z1rMtbh4qKt+LNPfXuIdU3leCKgzQ5MgFfy2kAyoJSONr0T1j94jlc4mT2fgunKtyrdjcO82FC/xRSG4XV2b2Qbh4yuJEkSbpBORwOiouLz8w0bK6i+KCG0sNaQEHrJYhoo1LPkUnwP+ehz8kBoKp1a8qHDOaosZAFhe9R6CwEoJV3KwaHDCZUhYZHPiIy71sA7PpAMho/TF74HZQ7FBbuquKHbPfQbn+jlufvasRDnRui0147i/JKNzYZ3EiSJN1gaoZ4FxQUeFbxNhU5yN+uw17uztb4x6mENbcTsn41ft98g6KquPz8KBs8mNJbmrG8fDmbC91ruAVqA7kv6D5a+7YkMm8dicc/Re+sBCAnujenGo2gSuPL2lNOFh+1YXW6Zxe+95YoXurTnFA5u7D0B5PBjSRJ0g3E6XRSUlLiydaYzRZKDkPxAR0IBY1BENbKSaiaSfCH89Hn5gJgaduGivvvZ6f2BIvy/kaF6p5wr7NfZ/oF9iPMWkiTna8QVOEeIWXya8CRJk9iCkpif7GL2fst5JjcQ7tbRPsxoX8LbkmQswtLdUMGN+dxk/Wxlq4i+dmR6tIvh3hXFtso2K7FWuJuDvKJVIloaSPk21X4r1uHIgQufz/KH3iA/BYN+KL0M/Za3TN8h+nCGBo8lMa6GBpmfk7s6aVohAuXxouTDdPJirmbYruG+Tuq2JrnHtpdz1vHuF5NGNKhPhqNnF1YqjsyuDmLXu+eFdNiseDt7V3HtZGuRxaLBTjzWZKkP4KqqpSXl3uaoSorTZQeUyner0O4FBSdIKylixA1g9APF6CvXq/N0r4dpfcO4kdlH1/lvYtVWNGgoUdAD3oE9CCyZBdNj/0DL1sBAIWht3KiyeNU6IJZneHiq+NV2F2gUWBo+xjG9W5OoI+hLm+FJAEyuKlFq9USFBREQYH7f2QfHx+5tol0SYQQWCwWCgoKCAoKuugaVpJ0NdntdgoLCz3NUKZSKwU7dFQVugNsr1CVyBZWwr5bhd+337qzNQEBlA4ZTFZyNAtLP+W43T3Dd7w+nqEhQ2mgGmh88H3Ci7YAYDWGcaTRY5RFpLIr38G8Q1byqhe4bBMbwFsDW5AcE1Qn1y9J5yODm1+IjIwE8AQ4knQ5goKCPJ8hSfo91Qzxzs/Pp7i4mIqKSspOqhTv1aM6FBSNILi5i3BdBqH/mYe++jvN3K4dxYP6s0HZzqr8OThxYlAMpAWk0c3/duJyVtLw5Dx0LisqGrLj+nMiYQiFDi/mba9iR767CSrUV8/LaU0Z1FYucClde2Rw8wuKohAVFUV4eDgOh6OuqyNdR/R6vczYSH8Ip9NJUVERhYWFlJSUYCqromCXFkuuO1tjDFKJbGUlbNMK/Ndv8GRrSoYM5nizYBaWf0K2wz1JXxNjEwYHDaaBtZxmO18iwOTO4pT7N+Fos6coNsaz8qSLr09YcKig1cBDHeN4vmczArxlE5R0bZLBzQVotVr5oJIk6ZpydvNnYWEhFRUVlGY6KNptQLW5F7sMauIkwnCC8CkLzmRr2rejYEA/VvE9G4tmoaLio/gwIGgAHfXNaXRqAXG5q1BQcWh9ON7gIXKje7KrUDB/u40Ci7sJqn18IBMHtqBpVGBd3gZJ+lUyuJEkSboOqKpKcXExBQUFlJaWUlFqonCvBlOmEQC9n0p4iyoit6wgYMPGWtmavY29+KJiCkUu92KWt3jfwqDAgTQo3U/TE8/hZS8BIC/sdo4mjiLXFcj8XU52FriboML99Lyc1owBbeJkE5R0XZDBjSRJ0jXOarV6sjVlZWWU5zoo3KHDadEAgoCGLqJ8TxA2bT6G6myNqV078gb2YZm6nh9LfwQgQBPA/UH3014TQZND/yasdDsAFq9IjjR6grzAVqw65eLrE1ZPE9TIW+N5vmcz/LzkCEDp+iGDG0mSpGuUEILy8vIznYbLKincDxXH9YCCzlsQ1qKKqK0rCNxwpm9N8eD72d5Yw5cV/6FcLQcg1SeVewL60DTvWxqeegetakNVdJyKHcCp+PvYVapn3o92TxNUh4RAJg5sSZPIiy9QKEnXIhncSJIkXYMcDgeFhYUUFBRQVlZGaW4VhTv0OCrdE/L5xTuJDDhJ5KfzMOTnA2Bq15as/j350rWWXWW7AAjVhnJ/4P20c2pI2vMG/uYMAMoCkjjUaDSZ2lgW7HOxI98GuJugXunTjP63yCYo6fpV58HN5MmTmTRpErm5uSQnJ/Ovf/2LLl26nLfs999/z4svvsihQ4ewWCwkJCTwxBNP8Pzzz//BtZYkSfp9CCEwmUzk5+dTWFhIeXkFJYeh9JDBs3xCaAsrsTtXELh+vSdbU3T/ffzQyM5Xlf/BIixo0HC77+2keXUhOetL4vNWoSBw6Pw42uAhMsO6sToTlp+weZqgRtwaz1jZBCXdAOo0uFm4cCHPPfcckydPpnPnzkydOpW0tDQOHDhAfHz8OeV9fX15+umnadmyJb6+vnz//fc88cQT+Pr68vjjj9fBFUiSJF09NetC5efnU1RURHlhFUU79dhK3SM3vSNcRIedImrOnDPZmrZtOTngLj53ruRg9bpP0fpoBgcMpk1FDklHXvR0GM4Nu52jDUeys8KfeVtc5Fc3QbWLD+DtgS3lKCjphqGIOlwMp2PHjrRp04YpU6Z4tiUlJTFgwADefffdSzrGoEGD8PX1Zfbs2ZdUvqKigsDAQMrLywkIkG3JkiRdG6qqqsjPz68eDVVGyTEXpQcMnuUTgpOsxB1YSb316z0reBfdfx/fNjazwrQCm7ChRUtP/5700rYg5eRMIkq3AWDxiuBQ4hMc92nFwiNOtuW7ADkRn3R9uZznd51lbux2O9u3b+ell16qtb1nz55s3rz5ko6xc+dONm/ezMSJE3+PKkqSJP3uVFWlrKyMvLw8iouLKSmooGi3HmuBe4i3MdhFdORpYr6Yg6F6BW/zLa05OuAOFrhWcKLyBAAJ+gSGBN5Hu8KdNM78MzrViqpoORl9D8di72Ntjp6vdtmwuUCrwIMdYnmhd5KciE+6IdVZcFNUVITL5SIiIqLW9oiICPKqF3W7kNjYWAoLC3E6nbzxxhs8+uijFyxrs9mw2Wye1xUVFb+t4pIkSVeJw+EgPz+f/Px8SktLKc6wU7LHC9WhgEYQ1NhGwonVBC/5xp2t8fWl4N6BrGlayWrTf3HiRI+ePv59SCOGlAMfEmh2zzBc5t+UA4lPsMMex7xtTnLM7jlrbokNYKJcC0q6wdV5h+JfpkKFEL+aHt20aRMmk4ktW7bw0ksv0ahRI4YOHXresu+++y5vvvnmVauvJEnSb1XTaTg3N5eioiJKiyso2KVgyfYCQB+gEhmdRfxXszHm5ABgbtmSAwM6s0Cs4rTpNACNDY0Z7NuPjnnfkpDzHzTVMwwfq/8g+4Pu4ovjgi157mVk6nnreLF3U4Z0SJBNUNINr86Cm9DQULRa7TlZmoKCgnOyOb/UoEEDAFq0aEF+fj5vvPHGBYObl19+mbFjx3peV1RUEBcX9xtrL0mSdGWcTifFxcXk5uZSUlJCyWkrRbsMuKqqJ+RrYCchZy2h/1uD4nLh8vGhYGB/ljUtYX3VdFy48FK86OffjzSrnuT9b+NjKwQgLySVgw1GsaYgkCU/uahyggIMbhvNy32TCfKRTVDSzaHOghuDwUDbtm1Zu3YtAwcO9Gxfu3Yt/fv3v+TjCCFqNTv9ktFoxGg0/qa6SpIkXQ0Wi4W8vDzy8/MpKymncD9UnjACClpvlYj4XOqvmI3XaXdmxpyczN6BnZnHCvKq3D8Emxua84B3dzqeXkx08Q8AVBlCONjwMbbp2jB3j4tTFe4Ow80jfXl7YEtuSQiuk+uVpLpSp81SY8eOZfjw4bRr147U1FQ+/vhjMjMzGT16NODOumRnZzNr1iwA/vOf/xAfH0+zZs0A97w3//d//8czzzxTZ9cgSZL0a1RVpbS01NMMVZJjpminAUele4i3b6ydhJJvCZ+2Eo3Ticvbm4IBd/Nls2K+s85AIPBVfOnv15++lSU0O/Y6BpcZgcKpqD7sjhzMl5lGvst2IgB/o5ax3RvxUOdEtBrZBCXdfOo0uBkyZAjFxcVMmDCB3NxcUlJSWLFiBQkJCQDk5uaSmZnpKa+qKi+//DIZGRnodDoSExP529/+xhNPPFFXlyBJknRRNpvN02m4uLiEokMq5Ye9qifkUwmLL6Th2k/xPnUKAHOzZuwceCvztKsosroXumxtbM0QXQdSM+YRUnkAgArf+uxr8DhrTA1ZtF2l0u6es+aelhG82i+FMH+vurlgSboG1Ok8N3VBznMjSdIfQQhBZWUlOTk5FBYWUpxX4Z6Qr8T9m9IrzEH9qu+JXL0UjcOBajSSd08anyUX86NtCwKBv8afQb79uafkOInZX6IVDlwaA8diB7MlsC9zjyocKXMHNQ1DvJk4IIVOjcPr8rIl6XdzXcxzI0mSdKNyOp0UFRWRm5tLcXEJBUeslB3wQjgVFK0gOL6ERhtn4nvCPUeNpXEjfh7QnvmGbyi1lQLQzqsd6STR8egs/KvcfXCKAluyM+FRFuVHsHabC5cQeOk0PH1HQx6/oxEGnbbOrlmSriUyuJEkSbqKLBYLubm5FBQUUJRfSsFODdZ8bwD0gU7q8zMxcz9HY7ej6vXk9enJ3FbFbHV8DioEaYK4z+du+udvI6HgHRQEdp0/BxNGsIrOfLYHiq3uDsN3NgnhzQEtiAv2rctLlqRrjgxuJEmSrgJVVSkpKfF0Gi48YaF4jxHVpgFFEBhbTtOfZuF35DAAVfXr8+Ogdsz3Xk+5oxyAW423MtwZSftD/8Xb4V4PKjv0djZHpDPnVAC7i9y9CKICDLxxTzK9UqLr5mIl6RongxtJkqTfyG63k5ub617wsrCEgt0Cc6Y7W6PzcRFj3EX9L+ahrbKi6nTk9bqTWW1K2OFcAioEa4J5wNiT/rkbiC79DACzMZw98Y/wmbklX+8S2F0CnUZhVGocz/dMwscov74l6ULk/x2SJElXSAhBRUUFOTk57mao0yaKdhpwmt19X/wiTTTeO496+3cDYI2N5YdBbZnrtxGT04SCQidjKqMsXtxy8iMMLgsqGjIi+7La/17mnDCSY3Zna9rE+vPuva3kyt2SdAlkcCNJknQFnE4nhYWF5ObmUlhYRME+JxXHqod4G1Wi/A6SuOxTdGYzQqMh967bmdGxnN2ur0FAqCaUdN0dDMheSWjlQQDKfOqzJeYxZhc15IeTAhAEeet4SS6bIEmXRQY3kiRJl6mm03B+fj75p0so2mnAXuaeV8Y71EqT458RsvonAGyRkfwwqC2zg77H7DKjoNDF2InHKx2k5PzbM7z7SMz9LFDSWHRIg8nhztbc2zqSv/ZLoZ6vnGVdki6HDG4kSZIuUc1Mw9nZ2RQWFpF3yEL5AW+Eyz3EO6xeBk3W/A9DRQVCUci/PZVpnU3sFqtBQLgmnBHaVPqf+orAKvekfYUBLdgQ+QgfZ0ZwtMwd1DQK9eadQS3o0DCsLi9Xkq5bMriRJEm6BHa7nby8PLKzsykuKCN/h4I13wcAfYCdxgXLiVy3zl02JITvB7ZhVvhPWIQFDRruMHZmdEkxzQo+cg/v1vqxJ+ZB/mfpwjd7leo5axSe6ZbIY13lnDWS9FvI4EaSJOkiamYazs7OJi8vj8IMC8W7zwzxrhecS/P1/8VYUgxAfmo7PulqZbeyHgREaiJ5hNb0O7EEX3sBANnBqSwJeIgZJwMpsrrPc0ejYN4a1FLOWSNJV4EMbiRJki7A5XJRWFhITk4OebkFFOwRmE+5h3hrvZ00MK0j7stlKELgCAzkhwG3MDNmhydb002fytNFp2lU8jEAVfoQtkSP5KOStmw/5D5HuJ+eN/ol06dVTF1dpiTdcGRwI0mSdB4Wi4WcnBzy8/PJzSilaKcBl9n9lelfr4Tmm6fgm58DQGGblnx8p4Pd+u892ZrHnY3pd2I5Xs5yBAoZod2Zrh3MomO+VLlAo8CDHWL5S1pz/L30dXmpknTDkcGNJEnSWYQQlJSUkJ2dTUFBIbl7rVQc8QahoOhV4l1baLh0Poqq4vT1Zcs9bfhf/V1UUYUGDXfpOvBc/hHiK+YCUGmMYm3EY3yY24yTle5zNI/05d1BLWkVH1yHVypJNy4Z3EiSJFVzOBzk5eW5m6FOF1GwQ4e9xN0M5eVvInnPNAJPHQGgpHkTPu6lYYfXjwBEaSJ5yhZHn8zl6F0WVLQcCr+bD5yDWHtUjyrAR6/hhR6NGHlbI7QaOWeNJP1eZHAjSdJNTwiByWQiOzub3Nxc8g6bKd3nhXBqQCOI0O2n2apP0DocuLy8+DmtFf9tup8qxYoWLXdp2vDn/P1EmRYBUOrTkEX1HmFKdgOKqzsM92gWwoQBLYkK8qnDK5Wkm4MMbiRJuqm5XC6Ki4vJysoiL7uA3B0Ca271EG8fK82OzyPs8HYAyhPr878+Bn72c7+O0kTybFU4vXO/QiscOBUDO8Pv5W+mvmw/rgEg0t/Am/3lIpeS9EeSwY0kSTctq9XqGeKdc6yUop1GVKsWENTzPkXK+snoq8yoej07uqfwUaujWBQrGjT00LTmxdxdhFl+BqDAL4np3o8wMysaa3WH4Yc6ujsM+xplh2FJ+iPJ4EaSpJuOEILy8nIyMzPJzysgZ5cN0wlvQEFjcJKY/xVxG9wT8plio5jez5/vg/YCEKlEMNYSRK+8ZWhwYdd480PYMCaU3ElGkbsfTfNIX/52b0taxskOw5JUF2RwI0nSTcXpdHpmGs49VUz+di3OcnenYV/vQlpu/gjv8iKERsO+rsn8s8NJTJpCNGjoqaTwUvZOQmxbAcgKaMO/tKNYnBmCq7rD8NjujRjVRXYYlqS6JIMbSZJuGhaLhdOnT7sDmwMWyg96IVwaFK1KnGkjjTZ8AUBVWAiz7qnHunD3at0RSjjjKn3oUfg1CgKrLoBVwQ/xdkEqhVZ3EHNnk2DeGtiSmHpyhmFJqmsyuJEk6YYnhKCoqIjs7GyyM/PI2aZiL3B3GjZ4VdJix1QCCzIAOHxrU967LZcy/UkUFHqJJF7J2k49RyEAxwM7MdE1nPWZgQCE+eqZ0D+ZtJZyhmFJulbI4EaSpBuazWYjNzfXHdgcKaV4lxHVZgBFEO7cTfPV09AIFVugPwvuDufr+OMARCihjKsw0LNoFQAWfT0+8xvFpMJ2mJ2gAMPaR/NS3xQ5w7AkXWNkcCNJ0g2pZsHL06dPk5uTR9Z2K+aT7k7DWr2NpCOzCT+1E4CTLRsw6a4SCr1OoaDQU23MX7O3E+QsBWB/YDfGVw1jV667yalRqDd/v68lbeuH1tXlSZJ0ETK4kSTphuNyuSgoKOD06dPkZBSRv02Ls9LdaThAOUnLDR9hcFTh8PZmaZ9IPmtyGoAwgnmpXEPPkm8AqNSH84nPI0wubIFDBYNW4Zk7GvBEtyYYdNo6uz5Jki5OBjeSJN1QrFYrp0+fJisri+y9ZsoPeYGqQdG6aJizjISDawHIaxTD39NMZPu5A5seroa8nr2dQFclAoXtAT35S+UQMvK9AOiQEMDf72tNgzD/Ors2SZIujQxuJEm6IQghKCsr49SpU+5Ow1sF9kJ3p2EvbTGtf/4In8oCXHo9q7tHM7NVFigKIQTxcpmgV+kGAMqM0fxL9xifFjRFAIFeWl5Ja8rgDvVRFDm8W5KuBzK4kSTpuud0OsnNzSUrK4vMg8UU7zIi7FpQBNEVm2m6fT4KguLYMN7r6+BYcDagcJczjjdzdxHoNKOi4Xv/vvy5/F4K7AYA7k4O482BrQjxM9btBUqSdFlkcCNJ0nXNYrFw8uRJcrJzOb3NiuWUu9OwTmshZe8nBBccRtVo2NQlhsm35qJqFILw5+VSlT5lPwBQbIzjbeVxvixMBCA6wMDbA1vQLSmyDq9MkqQrJYMbSZKuS0IICgsLyczMJOt4AXlbtbhM7k7D9RyHafndf9GqdipDAvl3Pw27ovIAha7OKN7K2Us9lwUXWtb63sO48gFUOPWe9aDGpSXjY5Rfj5J0vZL/90qSdN2x2Wzk5ORw+vRpMndXUH6wutOwxknjjM+JzfgegJ3tonj/jkJsegjAl5fKXPQr/QmAfGN9xrtG801xPABNw334+32taB0v14OSpOudDG4kSbquVFRUkJmZyakTWbU6DXuLfFpv/jfe1lKsft78r683mxq6ZxXu5Ajn3dz9BLuqcCk6lnoN4pXyu7GqOoxahae7NeTJbk3QaTV1eWmSJF0lMriRJOm64HK5KCws5OTJk2QeKqJopwFh0wGCuKL1NNr3JQqCo83C+HuvMip8KvDFm3FlLgaVbgMg25DInx1P8GNpLAAd4gP4232taRguh3dL0o1EBjeSJF3zbDYbmZmZZJ46TeY2C5bqmYZ1ipkWu6dSr+Q4ToOe+T39WJZSAopCW2cw/8g5RLjLilPR85nxfl4r64MTDf5GLS/1bsKwWxvI4d2SdAOSwY0kSdcsIQTl5eVkZGSQeSyP3J8VXJXuZqhgy35Stk9D57KRExfEu3dbyA+qxEsYeb5MMLR0FwpwytCEZ22Ps6ssGoAeTYN5+95bCA/wqsMrkyTp9ySDG0mSrkkul4u8vDwyMjI4tbuMsgNe4NKgKE6aHF1ATNaPqBoNy++ox+yOFQiNQgtnIP+Xe5RopxWHYmCOfjATKnoj0BDqq+Ot/smktYyt60uTJOl3JoMbSZKuOVVVVWRkZHD6VA6ZW+zY86s7DTvzaL31P3jbSigN9WNSPwfHIisxCD1/Khc8XLIXBThhaMpTVaM5WBUBwP23RPLXe1oQ6G2ow6uSJOmPIoMbSZKuGUIISkpKyMjI4OSBfAp36FGtXoAgNn89jQ4tRiNUvm8XxJQ7KnHoFRo7/Xk/7wT1HVU4FCPTdUP4W0VPBBrigoz87d6WdG4cXteXJknSH+iKgps777yTrl278vrrr9faXlpayr333su33357VSonSdLNw+l0kpWVxamTpzi5tRLTCW8QCjpR3Wm47DgWXyP/uVtha0MTOqHjiQp4sng/WuCYvil/sozmSFUEGgX+v737Do+qzNs4/p1JmYSQhBJIAYQgIEF6QIqyCiqCgoCoYEGUXVcQC+JakFURXbFhXUVBiigKoiBKUTqCgCImGDqEQCCkk16mnvePaN6NdAiclPtzXXNdmTPPnPzOw8nMzSnPM6JbI/7VpxX+vvo/nEh1c05/9WvXriUuLo6YmBjmzJlDQEAAAA6Hg3Xr1pVrgSJS9eXn53Pw4EEO7jtC0mYDV07JaajaeTtpvW0GPq4idrYIYnLfAvJqWGjsrsHklEQucxTisNj4wDqUN/Oux8BKi3r+vH5be9ppMD6Rauuc/0uzcuVKHnjgAbp27cp3331HkyZNyrEsEakO/pxCISEhgQPb0jn2uw1cXlhw0Xz/fBoc2YDLx4sZff35vl0BFqzcnWdhbMZufIC93pcxqnAk8Z5QfLwsPHxNJCN7tsDX28vsTRMRE51zuAkPD2fdunWMGDGCzp07M3/+fKKiosqzNhGpwpxOJ4mJiSTEH+LQz0UUJ5UcrfFzptHutykEFKVxJCKAV28uJrW2kzC3P6+lJtHBXoDT4svbDOWd/JJra9pF1GTykA40Cw0yeatEpCI4p3Dz56BXNpuNOXPm8NJLL9GnTx+eeuqpci1ORKqmvLw84uPjSdh9lJRfvPAUlkx4GZH6Iy12f40FN99d6c+cq4rxWC0MKPBifPo+/A2DPV4tGFk4igQjFH8fC49f14wRPZpjtWowPhEpcU7hxjCMMs///e9/ExUVxfDhw8ulKBGpmjweD2lpacTHx3Pg12Pk7vEHjxUvo4jL42YQcmwn2bVsvNHfYG9DJ7U9Nl5OSeWqojycFh/eYijvFtyAgZWujYN47bYOXBJS0+zNEpEK5pzCTUJCAvXq1SuzbPDgwbRs2ZJff/21XAoTkarFbrdz+PBh9u9JIHGTE2dGyY0IQfnxtN02DV9nHpva+DPlegfFNgu9Cr14MT2eII/BHmtzRhaNJMEIJ9Bm5Zm+LRnapYmmThCRE7IYfz0MU8Xl5uYSHBxMTk4OQUE6Py9yMeTm5hIfH8/+bUmk/+aL4fAGPDRN+JbGh1Zi9/Piwz6wMQoCPN48l5HJjQU5OPHhv9zOe8V98WClZ/PavHpbR02dIFINnc33twaAEJELxu12k5qayr69+0j4JY+CAyUTXvo6s2j7+1SC8hLZf4kfk/s7yQyy0LnYi1fTDlLP7WGftSkji0YRbzSglp8XE/pHMaDjJTpaIyKnpXAjIheE3W4nISGB/TsPcmSzgTu35G6oehm/ErXrcyyGgy+u8eGbLk58LF48k5nD0Nws3Hjzjuc23inujwcrfaNCeGlwe+rWtJm8RSJSWSjciEi5y87OZv/+/ez/LZXM331Lxq4xHETt/pyw1C2k1/HljZutJIQbtHR4Mzn1MJe4XMRbGzOq6EH2Go2oW8OblwZqoksROXsKNyJSbtxuN8nJyezbu58DPxVQnFRyi3dAURJtfp9GjaJ01rT3Zca1bpw+VkZmFfBAdgYWrHzgGcybxQNw4c2ANvWZOKgdwTU00aWInD2FGxEpF3a7nQMHDrA37hBHN1tKx65peGQVzeIXUewHrw228msLDw1c3kw+eoTLHU4OWRoyqvhBdhpNqF/Tm0mD2nDt5REmb42IVGYKNyJyXgzDIDs7mz179rB/SwY5u/xKxq5xF9J6x0zqHtvJziY+vNPPQ1agldtz7TxxLA1fAz723MxrjsE48OG2DqE8N6AdgX4+Zm+SiFRyCjcics7cbjdJSUns3b2fhA3FONJKLhoOztlL6x0z8XLnMbuXlSVXeKjl8eKj5BS6FxdzxBLGQ/YHiTWaER7owyuD23B1y3CTt0ZEqgqFGxE5J3a7nfj4eHbHHCTlFy8Mux8Yf4xdk7iS1DpeTB5o5VCohWsLnLyQkUSgx+BTTx9ecgzFji9Do8N49ua2BNh0tEZEyo/CjYicFcMwyMrKYs+ePezbmEnefn8wLPg6smmz/WOCcxNY2d6LWdcZeHtZmZSWzk0FhaQRwj/to/jZiCIiyIfXb23HlS1Czd4cEamCFG5E5Iz9eRpq9/b9JKwvxpVVchoqJCOGqN1zcHjbeX2wlS0tLHQodvNq8lHC3W7me3oywXE3hfhzV6dwxvdvSw2bPn5E5MLQp4uInJHi4mL279/Pri2HSP/NB8Pph8XjosW++UQkb2BnYy/e7W8ht6aFsZnZDM/NJZtg7nU8wFpPexoG+zLt1rZ0b66jNSJyYSnciMgp/Xkaaveu3ezdkEVBgh9gwb8olTbbP8a/6Chzelr5rgs0dsG0o8lc5nCy1NONcY77yKUmwzpHMK5fGx2tEZGLQp80InJSbrebI0eOsHPbPg5tcOLOLRm7Jjz5J1rsm09GsJuXbvPiQLiFO3PyGZt1DLsRwGjHKJZ4utIw2JcPb21Ht+b1Td4SEalOFG5E5ISKi4vZt28fOzcnkhHrC24bVredlnvmEJa2lbVtrEzvbaGml4WPktPoXlzMOk97/uW4nwxqc3fnCJ7R0RoRMYE+dUSkjD9PQ+3YvpN963MoOlxytKZm/mFa75iOxZ3BWwOsbGpl5dqCYiYkZ2Dz+PC08x/MdfekQZCNObfp2hoRMY/CjYiUcrvdHD58mO2/7eXwTx48BSXBptHh1Vx6YBH7Izy8c7OV/CALE9MzGZhfQIzRgkcdozhshHJHdBjP3txOR2tExFT6BBIRoOQ01N69e9n+UyJZcX7g8cbbVUirXZ9Q59h2vu5u4eurrLRyuPgkKZ0wF0xy3sHH7psIDbTx2a1tueqyMLM3Q0RE4UZE4NixY+yI28metTnYk/+cQiGey3fOoNA3hxfu9GJPIwsjs7O5PzuXeOMS+jkeZI9xCbf/MSdUTc0JJSIVhNXsAj744AMiIyPx8/MjOjqa9evXn7TtggULuP7666lXrx5BQUF069aNH3744SJWK1K1uN1uDh48yE+rtrD9m3zsyf5gGDQ+tIwOsW+zrXEOj//dSk64wSfJKfwzO4+prpvpb3+R7ICmzBrekdeGdFKwEZEKxdRwM2/ePMaMGcP48eOJiYmhR48e9O3bl8TExBO2//HHH7n++utZunQpW7dupWfPnvTv35+YmJiLXLlI5VdcXMyOHTv4afF2Etd44SnyxceRS/vf36PR4cV8fANMvsXKda5CFiQlUbe4Frfbn+M111BubBPBisd7ck2UJrsUkYrHYhiGYdYv79KlCx07dmTKlCmly6Kiohg4cCCTJk06o3VcfvnlDBkyhOeee+6M2ufm5hIcHExOTg5BQUHnVLdIZZeVlUXcth3sWZODI7XkouHaWbtptesTUoPzeHuAley6MCE9gxsKi/jC1ZMXXcOoUSOASbe04frWDUzeAhGpbs7m+9u0a24cDgdbt27l6aefLrO8d+/ebNy48YzW4fF4yMvLo06dOidtY7fbsdvtpc9zc3PPrWCRKsDj8XD48GFiN+8maRMYxf5/zOS9mMaJy/mhI3zay0o7l4OZRzLwcQUwwjma1Z6O3NSqLv+5tSO1aviavRkiIqdkWrjJyMjA7XYTGlp2LIzQ0FBSUlLOaB2TJ0+moKCA22+//aRtJk2axAsvvHBetYpUBXa7nd27dxO37jA5u/zAsOJrz6b1zhl42w/w+mALMc2tPJKVxfCcPFa5o3naeT8ev9q8P+hybmrXyOxNEBE5I6bfLWWxWMo8NwzjuGUn8sUXXzBhwgQWLVpE/fonH9p93LhxjB07tvR5bm4ujRrpQ1qql+zsbH6P3c6eVbk40kvuhqqbuYOo3Z+wP6yAd2/2ItDPzZyjqTSxezHOdT9fuq+hZ7PavD4kmpBAP5O3QETkzJkWbkJCQvDy8jruKE1aWtpxR3P+at68efz9739n/vz5XHfddadsa7PZsNls512vSGXk8XhISkrit592lpyGsvuB4ebSA9/S8MgqvrrKwoLuXgzOz+eJo9nsdDenj3MUWT7hvDGgJYM7Nzmj/2yIiFQkpoUbX19foqOjWbFiBYMGDSpdvmLFCgYMGHDS933xxReMGDGCL774gptuuulilCpSKTkcDvbs2UPs6kPk7i45DWUrPkbrnTNwGQlMvNOLpAYGb6VncHWBgzddt/Gh+2a6NK7FvKEdiagdYPYmiIicE1NPS40dO5Zhw4bRqVMnunXrxtSpU0lMTGTkyJFAySmlpKQkZs+eDZQEm3vuuYd33nmHrl27lh718ff3Jzg42LTtEKlosrOziYvdwa6V2TgzSk5DhWT8TtTuT4mNLGLKjV60sthZkJRJvjOUgc4H2e91Kc/3a849VzbT0RoRqdRMDTdDhgwhMzOTiRMnkpycTOvWrVm6dCmNGzcGIDk5ucyYNx999BEul4vRo0czevTo0uXDhw9n1qxZF7t8kQrHMAySkpLYumHHH6eh/LF43Fx64BvCklcz+1orKztYeDg7m3tz8vjU1ZtXXHfQMqI239/RiSb1As3eBBGR82bqODdm0Dg3UlU5nU727t3LbysSyN3zP6ehdkwn3+cgbw/0wlPHxWtpmdS3+/OEcyQbaceYXk0Z1aslVquO1ohIxVUpxrkRkfKTl5fHtt/i2Lki67jTUBuiipjR24u+9gLGJWWx3hXNMOc/qBdSn2/vjCYqopa5xYuIlDOFG5FKzDAMUlJS2PJjHEc2GmVOQ4WkrWZKXyuxURZeyszkb/luJrj+wVeea/hH90b868bW+Hp7mb0JIiLlTuFGpJJyuVzs27ePX5fH/+VuqOlk1jjI0/d5EV7DzldHM0lzRNLX+SDuoEbMG9KBzk3rmV2+iMgFo3AjUgkVFBSw7bc4ti/PxJle9jTUivZFfH6Nlb/n5zLiaB4fugfynmsQt3YI5/mBHahh05+9iFRt+pQTqWRSU1PZ8uPvJP7kwSj+8zTUImpnrOKtAVaONDWYmpZBSFEwdzofI9E/iml3tKXX5RFmly4iclEo3IhUEm63m/j4eH75fu8fc0P5lA7KlxyUwKQRXnT0LuLtpEyWO3pwj2s4V14WwfTbo6kdoFG6RaT6ULgRqQSKi4v5PXY725am4kj7c26o7bTcNZslVxSy6EorT2Yf47pMg3HOh/nRuxsTb4li8BWRJlcuInLxKdyIVHDHjh3j53WxJKxzYBT7/zE31HcEHVvJa7dasEe4mZuSQWpxC/o6R9Gw4SX8cGdnGtTR9AkiUj0p3IhUUB6Ph0OHDrFp2U6y4mxg+OJrz6b1zhkk1j7ASyOs9HPn89DRXN5z3s4n3MRjvZvxz54tNX2CiFRrCjciFZDdbifu9x3ELjmKPaXkNFTtY7uI2j2Lb7oWsuYKg5cyM2hUUIuhzsdx1I1i0V2duCy8lrmFi4hUAAo3IhVMdnY2P6+PIX6NHaOwBhgeIg8uIyhzGZNus1KznoP5yZmssv+NB13DuKNrU57q11YD8omI/EHhRqSCMAyDI0eOsHFZHBmxPuDxxceRy+U7Z3Gozl5eHmFhmCOHwckexjsfYVuNbkwf0p5uzUPNLl1EpEJRuBGpAFwuFzu27+TX7xIpTio5DRWcvZ+oXTNY2C2PXzoZvJueQVFhM25yjqLL5c1ZeVs0Nf18TK5cRKTiUbgRMVlBQQE/b/iNPcvz8RSUBJtLEpcTnP4dk2630LB2MZ8nZTPNcRtfePXjpdtac3N0E3OLFhGpwBRuREyUlpbGj0t+I/VXK7hteDsLabX7Ew7V2sEb91l4sCiLzikB3OecgH/DNvxwZ2fCa+sWbxGRU1G4ETGBx+Nh3959bFy4j8JDJUdrAnMP0XL3dL7pmsXO9h6mpmewrag7gzzDGXltFCOvjdIt3iIiZ0DhRuQis9vtbNkUQ9zSTDy5JcGmQdI6aqct4JXBBq2DC/noaDEvOkayM/hq5g7rTFRELXOLFhGpRBRuRC6irKwsfly2hSMbDXD54+W2c9meOSQF/ca7w+HxgixC0xoy2Dmaazq2ZtnADth8dIu3iMjZULgRuQgMw+DQoUP8+PV28vb5AxZqFCTTauc0FnVJZ387Nx+nZfKdvT8veA/mtXs6ck2UZvEWETkXCjciF5jL5SJ26+9s/eYorqyS01ChqVsIOfoFr93ionNgAa8etfKkYxwBkVfww11XaBZvEZHzoHAjcgHl5+ezYcUWDqyxYzhqYPE4ab7/a1L9N/DyPQbjCrIoTm/NUM/9jL6xA8Ouaq6LhkVEzpPCjcgFkpKSwuqvfyMrzgfwxVZ8jFY7p7G04xES2zuZmpbDVPvdbK3Vh8/v6cqloUFmlywiUiUo3IiUM4/Hw84du9n09QEcf0x6WTdzB+GJn/BW/yKuCsrjzqOB/NP5Ilde0Znv+rfTvFAiIuVI4UakHBUXF7P5x63sXJaDUfTnpJdLyLYu5/W7PTxTeIwD6Vdyv/dwXruvC1e2CDO7ZBGRKkfhRqScZGVlseqbX0j9xQKGHz6OPKJ2z2LV5Xs50sHBOxkFvFY8EnuTa1lyVxdq6aJhEZELQuFG5DwZhsGhg4dYM3d76WjDQTkHuCRhOh/0yaVHrTz6ptTn7+5/M6JvN100LCJygSnciJwHl8vF1l+2EbMwBXdeSbBpeGQtTvsC3rzDzdOFx/gloy/PBg7h43u70yw02OSKRUSqPoUbkXNUUFDA2qU/c3CtA9z+WN12Wu6Zw6ZLf+NgZwevZrh4oXgsl3boxXcDO2qkYRGRi0ThRuQcJCcns3LeVnJ3+wG+1ChMoem+j5l5bSrdQvLoktyEB62jGX/nVVzbuqHZ5YqIVCsKNyJnwePxsHvnHjbM3Y8zIwCAemm/4Zv9Ge/dZmesPYtV6bewNnwwXw6/kpBAP5MrFhGpfhRuRM6Q0+lkw6pf2LU0G8MRgMVwc2n8QnaErmXvtQ6ey4AJ9nFc3+s6Pr+2lS4aFhExicKNyBnIzc1l+fxNpG4B8MfXnkPzvdOZe9UBOoTncWNKFE/6jeS1+66m7SV1zS5XRKRaU7gROY1DhxJZ9dk2ig6XnIYKzt5P7ZTpTBmYy8OuHJakD2VHi8EsGNqFGjb9SYmImE2fxCIn4fF4iNkSxy9fJuIpKAk2jQ6v4qjfIjYMtvPEMW9edD7LvQP7MKhzpMnViojInxRuRE7AbrezevEmElYVYXgC8HLbab73M5a0j6F5kzx6prbjpeB/8t59PbkkJNDsckVE5H8o3Ij8RWZmJsvmbCZnhy9YbNQoTCXi0FRm9U7h7155fJd+F4Edb+WrQdF4e1nNLldERP5C4Ubkf8TvO8Dq2dtxpNcEC9RLj8Vh/4yFg/IYmWPjdcdzPHLnjfTS2DUiIhWWwo0I4Ha7+eWnGGK/SsbjqAmGh6YHFrEpcjV1WuVxVUYHPqj/ANPu7Um9IH+zyxURkVNQuJFqr7CwkBULNpK0wYVBAD6OPCLjZzDv6r3cViOfZenD4MohfNa3rcauERGpBBRupFpLT0tnyazNFMTXAIsvQbkHqZExja/7ZzKs0MZ79gk8PaIfnS4NNbtUERE5Qwo3Um3t2bWftTN34MoNBAtEHN1AQuBXOPrm0j2zA581HMmM4T0J8vc1u1QRETkLCjdS7bjdbn5atYUdizLwuAOxeJw0jZ/H0o6b6VUvn3WZd1Pv2ruZek2UTkOJiFRCCjdSrRQWFrLsi/Wk/gKGpQa24mOEHZ7GwusOcrvLl4/tz/HvBwZxeSNNoSAiUlkp3Ei1kZqSxpJpmyhKKjkNVTtrD3bHTLbclEG3rNYsavwwH999DQF+PmaXKiIi50HhRqqF7dt2sWHWHtxFQQA0OrySXxt9S8tL8yg4NhSfPiN496rLTK5SRETKg8KNVGlut5u1yzazZ0kWhhGE1W3nkoTPWNb9N27ytfCF49+Mf/BWLouobXapIiJSThRupMoqLCzk20/WkhnrDZYa+BelE5T6EeuvP0TXwhasDB/L1GE98fPVn4GISFWiT3WpklKSU1kyZSPFacFggbqZ20nx+QTntRl45QzGp+8DTL5Sp6FERKoihRupcuJidvHTzN24HcEANEpcyoaWS7kyxM0i+9M8M3oozcJ1GkpEpKpSuJEqw+12s3rJJvYvzcZDMF6uIiISP2Hd32KJdjXkp7Cn+GDYtfj5aLcXEanK9CkvVUJxcTELP17JsThfsNSgRkEKXrnT2HPdQYJz++Ld91Fe02koEZFqQeFGKr2Uoyksfv8n7Jm1wQIh6bHE1/qUyO75xNvH8Pjoe2iu01AiItWGwo1Uattjd7Ph4524XbXB8NDw8BJ+avM9HQNqs7X2RN6+t6/uhhIRqWb0qS+VktvtZvXijSXX11hq4eUqon7SLGKv+o2Q4qtwXf0kr199udllioiICRRupNIpLi7mm49XkhnnC5YAahSk4CqaSsY1hzlm/wcjH3iAqIZ1zC5TRERMonAjlUp6Wgbfvr2G4mN1S8avydjGvpDZXNrSICZwEpPGDKKGTXNDiYhUZwo3UmnsitvHuo+24XaVzNgdcWQJW9stJsw7iqLOz/F6744mVygiIhWBwo1UeIZhsG7ZZnYtSsdjqYOXq4g6KZ+wv9tWXM7buPKex+jQNNTsMkVEpIJQuJEKzel08s3UH0jf5oNhrYl/YSoO+0fkd08l2X88zz9wF8E1bGaXKSIiFYjCjVRY2dk5LHj9B4oyQ8AKdTK3E19vJqHNgilo9RGTB/TAYrGYXaaIiFQwCjdSIcXvPcjKd3/B5QoBIPTo9+xq8w34XE2r257nyqiG5hYoIiIVlsKNVDgbV/3KtnmH8VhDsLrt1E75lOQuv5Ln/QBPPDiKekE1zC5RREQqMKvZBXzwwQdERkbi5+dHdHQ069evP2nb5ORk7rzzTi677DKsVitjxoy5eIXKBedyuVg4bSmx89LxWIPxK8rAkj+Z3K67KWj8Bq88OVbBRkRETsvUcDNv3jzGjBnD+PHjiYmJoUePHvTt25fExMQTtrfb7dSrV4/x48fTrl27i1ytXEgF+QV8NvFrjm71w7DaqJW1h4yAVyhqGUCD6+bw9LCbsVp1fY2IiJyexTAMw6xf3qVLFzp27MiUKVNKl0VFRTFw4EAmTZp0yvdec801tG/fnrfffvusfmdubi7BwcHk5OQQFBR0LmVLOUtKPMqS19fhdJbczl0vZTUHWs0n328g/xj5DE3qB5tcoYiImO1svr9Nu+bG4XCwdetWnn766TLLe/fuzcaNG02qSi623zbH8cuMPbitoVg8TmqnziUtejNFdZ/i2X8Ox+bjZXaJIiJSyZgWbjIyMnC73YSGlh18LTQ0lJSUlHL7PXa7HbvdXvo8Nze33NYt584wDJZ9sYpDa4rxeNXB154DRdPI6pRDzehpPHTjVWaXKCIilZTpFxT/dZwSwzDKdeySSZMmERwcXPpo1KhRua1bzo3dbufzSfNJWGfg8apBYO4hcmyTSI+qzRVDv+ReBRsRETkPpoWbkJAQvLy8jjtKk5aWdtzRnPMxbtw4cnJySh+HDx8ut3XL2TuWmcXsp78kOzEELF7UyfiFlEZvkN2kH6Me/5hOzRuYXaKIiFRypp2W8vX1JTo6mhUrVjBo0KDS5StWrGDAgAHl9ntsNhs2m4bnrwj27TrAqrc347Y0AMNDnbRFZLRdg3fTCbx4z60abVhERMqFqYP4jR07lmHDhtGpUye6devG1KlTSUxMZOTIkUDJUZekpCRmz55d+p7Y2FgA8vPzSU9PJzY2Fl9fX1q1amXGJsgZWr9sEzsWpOD2CsPLVYRv7kzSOmTQovcX9O3axuzyRESkCjE13AwZMoTMzEwmTpxIcnIyrVu3ZunSpTRu3BgoGbTvr2PedOjQofTnrVu38vnnn9O4cWMOHjx4MUuXM+TxeFj4wbek/u6H4RWMf2Eq+b5TSG/TjLvvn0ZkWG2zSxQRkSrG1HFuzKBxbi6e4qJivnhhPoXZJdfRBGfvJLXBdPIa3MFTDz2Gv6+PyRWKiEhlUSnGuZGqLeVoGoteWobLU3J3Wu30VWRELSGo3Ys8flt/k6sTEZGqTOFGyt22LTvYNDUOt1cjLB4XAVlzSW5ziCsGfUmPdi3MLk9ERKo4hRspV8vnriR+ZQEe7/r4OHJxu6dyqG0D/vnQIsJq1zS7PBERqQYUbqRcuN1u5r02j+yEEAzvQALyj5BdewoFzW/lmdGP4e1l+niRIiJSTSjcyHkrLCxizvg5OIqaghWCj8VwrOnn1Ok6kTEDbzK7PBERqWYUbuS8JCUms/il73FZmwIQnLGU1Ja/cvVd8+kU1dTk6kREpDpSuJFz9tuGWLbM3I3LpzFWtwPf/E9JaOfNyIcXU6+Wrq8RERFzKNzIOVkyczGJP3nw+NTH156Nw/tD0rtdw/iHxmG1ahoFERExj8KNnBWPx8OcibPJTW4A3l4E5B8kN2Qata9+mtGDym9OMBERkXOlcCNnrLCwiM+emoXTeRlYICjrVzKafsffhs0mulVzs8sTEREBFG7kDCUlJrN44hJc3pcBEHhsMUeiErn/sWWE6PoaERGpQBRu5LRiforllxm7cPk0xep24F38CYevaMzTY+fjpetrRESkglG4kVNaOus7EjcYuH1CSy4ctk3FeuPdjL/jbrNLExEROSGFGzmpT1/4mLykRhjePtTIP0Ru/Vl0uusdroxub3ZpIiIiJ6VwI8cpLirm0yem4XBdDlYIzI4hOXIlw8YuJKJeHbPLExEROSWFGykjNTmNRc9+jdP7cgBqZi8jMSqLJ8cvxtfby+TqRERETk/hRkrF/RLHpg9jcfpehsXjxLdoDjm92vLvf75udmkiIiJnTOFGAPhhzmISVjtw+zbAx5GHy2caYcMfod91vc0uTURE5Kwo3Aifvvgh+YmN8fjUwr8wmbw6s+n76DRaRF5idmkiIiJnTeGmGnO73Ux/7G2cjg7gBQF5O0lpuIrRz31DYIC/2eWJiIicE4WbaionO5d5/5qB07sDAAE560htk8lT4xZgsWhgPhERqbwUbqqh+N3xrHp1NU5bWzA8+BV8hbtvW5665wWzSxMRETlvCjfVzE9L17Hjq2SctkvxchWDZRbNRj/K1d2uNLs0ERGRcqFwU43Mf2cmmXF1cfvWx9d+jKKATxn0zEc0iggzuzQREZFyo3BTTUx/6nXsWW0xvH3wLzhIRthSHv3PV9h8fcwuTUREpFwp3FRxbrebaaNfw00XsEJAbgypLeN56rmvzC5NRETkglC4qcKOZRzjqyc/we3bBYAaectxXR/GU/d9YHJlIiIiF47CTRW1M2Y7P727CaetHRaPGx/HlzQddSdXX9XT7NJEREQuKIWbKmj53EUcXF70xx1RRbi9Z9PnP2/SqEEDs0sTERG54BRuqpjPXnmX/P1N/rgjKpP8oPmMfuNzfH30Ty0iItWDvvGqkGmPv4gz74rSO6IyG/3Ev/4zTyMOi4hItaJwUwUYhsHUBybisvYAK9TIjyG/YzZPjJ1udmkiIiIXncJNJZeTlc28sdNw2XoA4J+/ijq3t+W+mx83uTIRERFzKNxUYvvjdrNm8lqcftFgePCxf023Zx8m6rJWZpcmIiJiGoWbSmr5/AUcWlqIw68FVrcdj/ULhr77PkFBgWaXJiIiYiqFm0po9qtvUbS3CS5bBD6ObAqDFvLoW7N14bCIiAgKN5XOh088h5HdDY+PDb+iJLIb/MTjL39qdlkiIiIVhsJNJTJl1Hg8np7gZcW/YBfO6GM8PuZDs8sSERGpUBRuKgGP28O0+1/C43stWMA/fxMhg5ty86DRZpcmIiJS4SjcVHDJh4+w+Nl5uPyuAsBWtISuzwynVau2JlcmIiJSMSncVGA/r11H3Kw9OPw6YPG4sHi+4q6P3sXfz8/s0kRERCoshZsK6puZM0n/0YbDrxleriIcvl/z8PvTdUeUiIjIaSjcVEAfT3wR96E2uGxB+NizKKy7nDFvzDC7LBERkUpB4aaCmTL2aci7Go+PDVvREewtdjFm/EdmlyUiIlJpKNxUIB+MfALD6A1eXvgV7MJ2tcE//jHJ7LJEREQqFYWbCsDj8TDtH89h+PYFC/gV/syl93Xgml59zC5NRESk0lG4MVlmahoLn5yOy78XAL5Fy+n9n1E0atTY5MpEREQqJ4UbE61fuZI9n+7B7t8FDA9e7m8YMf0dvLy9zC5NRESk0lK4McmKr77k0HeF2P2jsLrtuH0WMfIjTaUgIiJyvhRuTPDJG69h39EEp/8leDvzsNdawSOTFWxERETKg8LNRfbhuHFY0rrhstXE156OMzKWR577r9lliYiIVBkKNxfR+488hrXoBtw+vtiKDmHrmsP9o3Srt4iISHlSuLlIPvjnWLDchMfLil/hDi65vQHX97vP7LJERESqHIWbC8ztcjH9/mcxbP0A8CvcTNsHr6Fz1+4mVyYiIlI1KdxcQMX5BXw2+m2c/tcD4Fu8grs/noDN12ZyZSIiIlWXws0Fsn7lSvbO3o69RjcwPFjd3/GPmW9rVm8REZELTOHmAli+8GsSvzmGvUZbLB4nhvd3jPpId0SJiIhcDAo35WzO+29TtKUedv9L8XIV4gxazsNvKtiIiIhcLAo35ejj/7yAJ741Tr/a+DiycDbcwsMT3zW7LBERkWpF4aacfDD+KaypPXD71sBWnIytQzL/fPQVs8sSERGpdqxmF1BVNGnfDi9XLraiAzS4ycKwR/9ldkkiIiLVksJNObnxtjup0SmVS++MoO9td5pdjoiISLWl01Ll6K6HHjO7BBERkWrP9CM3H3zwAZGRkfj5+REdHc369etP2X7dunVER0fj5+dH06ZN+fBDzaYtIiIi/8/UcDNv3jzGjBnD+PHjiYmJoUePHvTt25fExMQTtk9ISODGG2+kR48exMTE8Mwzz/DII4/w9ddfX+TKRUREpKKyGIZhmPXLu3TpQseOHZkyZUrpsqioKAYOHMikScfPlv3UU0/x7bffsmvXrtJlI0eOZNu2bWzatOmMfmdubi7BwcHk5OQQFBR0/hshIiIiF9zZfH+bduTG4XCwdetWevfuXWZ579692bhx4wnfs2nTpuPa33DDDfz66684nc4Tvsdut5Obm1vmISIiIlWXaeEmIyMDt9tNaGhomeWhoaGkpKSc8D0pKSknbO9yucjIyDjheyZNmkRwcHDpo1GjRuWzASIiIlIhmX5B8V8nkjQM45STS56o/YmW/2ncuHHk5OSUPg4fPnyeFYuIiEhFZtqt4CEhIXh5eR13lCYtLe24ozN/CgsLO2F7b29v6tate8L32Gw2bDZb+RQtIiIiFZ5pR258fX2Jjo5mxYoVZZavWLGC7t27n/A93bp1O6798uXL6dSpEz4+PhesVhEREak8TD0tNXbsWD7++GNmzJjBrl27eOyxx0hMTGTkyJFAySmle+65p7T9yJEjOXToEGPHjmXXrl3MmDGD6dOn869/aaoDERERKWHqCMVDhgwhMzOTiRMnkpycTOvWrVm6dCmNGzcGIDk5ucyYN5GRkSxdupTHHnuM999/n4iICN59910GDx5s1iaIiIhIBWPqODdm0Dg3IiIilU+lGOdGRERE5EJQuBEREZEqpdrNCv7nWTiNVCwiIlJ5/Pm9fSZX01S7cJOXlwegkYpFREQqoby8PIKDg0/ZptpdUOzxeDh69CiBgYGnHAn5RHJzc2nUqBGHDx/WxcgXkPr54lFfXxzq54tHfX3xXOy+NgyDvLw8IiIisFpPfVVNtTtyY7Vaadiw4XmtIygoSH80F4H6+eJRX18c6ueLR3198VzMvj7dEZs/6YJiERERqVIUbkRERKRKUbg5Czabjeeff14TcV5g6ueLR319caifLx719cVTkfu62l1QLCIiIlWbjtyIiIhIlaJwIyIiIlWKwo2IiIhUKQo3IiIiUqUo3JyhDz74gMjISPz8/IiOjmb9+vVml1SpTJgwAYvFUuYRFhZW+rphGEyYMIGIiAj8/f255ppr2LFjR5l12O12Hn74YUJCQggICODmm2/myJEjF3tTKpwff/yR/v37ExERgcVi4Ztvvinzenn1bVZWFsOGDSM4OJjg4GCGDRtGdnb2Bd66iuN0/Xzvvfcet4937dq1TBv18+lNmjSJzp07ExgYSP369Rk4cCB79uwp00b7dPk4k76urPu1ws0ZmDdvHmPGjGH8+PHExMTQo0cP+vbtS2JiotmlVSqXX345ycnJpY+4uLjS11577TXefPNN/vvf/7JlyxbCwsK4/vrrS+cCAxgzZgwLFy5k7ty5bNiwgfz8fPr164fb7TZjcyqMgoIC2rVrx3//+98Tvl5efXvnnXcSGxvL999/z/fff09sbCzDhg274NtXUZyunwH69OlTZh9funRpmdfVz6e3bt06Ro8ezebNm1mxYgUul4vevXtTUFBQ2kb7dPk4k76GSrpfG3JaV1xxhTFy5Mgyy1q2bGk8/fTTJlVU+Tz//PNGu3btTviax+MxwsLCjFdeeaV0WXFxsREcHGx8+OGHhmEYRnZ2tuHj42PMnTu3tE1SUpJhtVqN77///oLWXpkAxsKFC0ufl1ff7ty50wCMzZs3l7bZtGmTARi7d+++wFtV8fy1nw3DMIYPH24MGDDgpO9RP5+btLQ0AzDWrVtnGIb26Qvpr31tGJV3v9aRm9NwOBxs3bqV3r17l1neu3dvNm7caFJVldO+ffuIiIggMjKSoUOHcuDAAQASEhJISUkp08c2m42rr766tI+3bt2K0+ks0yYiIoLWrVvr3+EUyqtvN23aRHBwMF26dClt07VrV4KDg9X//2Pt2rXUr1+fFi1acP/995OWllb6mvr53OTk5ABQp04dQPv0hfTXvv5TZdyvFW5OIyMjA7fbTWhoaJnloaGhpKSkmFRV5dOlSxdmz57NDz/8wLRp00hJSaF79+5kZmaW9uOp+jglJQVfX19q16590jZyvPLq25SUFOrXr3/c+uvXr6/+/0Pfvn2ZM2cOq1evZvLkyWzZsoVevXpht9sB9fO5MAyDsWPHctVVV9G6dWtA+/SFcqK+hsq7X1e7WcHPlcViKfPcMIzjlsnJ9e3bt/TnNm3a0K1bNy699FI++eST0ovTzqWP9e9wZsqjb0/UXv3//4YMGVL6c+vWrenUqRONGzdmyZIl3HLLLSd9n/r55B566CF+//13NmzYcNxr2qfL18n6urLu1zpycxohISF4eXkdly7T0tKO+5+DnLmAgADatGnDvn37Su+aOlUfh4WF4XA4yMrKOmkbOV559W1YWBipqanHrT89PV39fxLh4eE0btyYffv2Aerns/Xwww/z7bffsmbNGho2bFi6XPt0+TtZX59IZdmvFW5Ow9fXl+joaFasWFFm+YoVK+jevbtJVVV+drudXbt2ER4eTmRkJGFhYWX62OFwsG7dutI+jo6OxsfHp0yb5ORktm/frn+HUyivvu3WrRs5OTn88ssvpW1+/vlncnJy1P8nkZmZyeHDhwkPDwfUz2fKMAweeughFixYwOrVq4mMjCzzuvbp8nO6vj6RSrNfX5DLlKuYuXPnGj4+Psb06dONnTt3GmPGjDECAgKMgwcPml1apfH4448ba9euNQ4cOGBs3rzZ6NevnxEYGFjah6+88ooRHBxsLFiwwIiLizPuuOMOIzw83MjNzS1dx8iRI42GDRsaK1euNH777TejV69eRrt27QyXy2XWZlUIeXl5RkxMjBETE2MAxptvvmnExMQYhw4dMgyj/Pq2T58+Rtu2bY1NmzYZmzZtMtq0aWP069fvom+vWU7Vz3l5ecbjjz9ubNy40UhISDDWrFljdOvWzWjQoIH6+SyNGjXKCA4ONtauXWskJyeXPgoLC0vbaJ8uH6fr68q8XyvcnKH333/faNy4seHr62t07NixzK1ycnpDhgwxwsPDDR8fHyMiIsK45ZZbjB07dpS+7vF4jOeff94ICwszbDab8be//c2Ii4srs46ioiLjoYceMurUqWP4+/sb/fr1MxITEy/2plQ4a9asMYDjHsOHDzcMo/z6NjMz07jrrruMwMBAIzAw0LjrrruMrKysi7SV5jtVPxcWFhq9e/c26tWrZ/j4+BiXXHKJMXz48OP6UP18eifqY8CYOXNmaRvt0+XjdH1dmfdryx8bKCIiIlIl6JobERERqVIUbkRERKRKUbgRERGRKkXhRkRERKoUhRsRERGpUhRuREREpEpRuBEREZEqReFGRM6KxWLhm2++MbuMcnfvvfdisVhM374JEyaU1vH222+bVodIZaZwIyJlvth9fHwIDQ3l+uuvZ8aMGXg8njJtk5OTy8zyfipmB4Wz1adPn+O2789+2bx5c5m2drudunXrYrFYWLt2bbnV8K9//Yvk5OTTTmAoIiencCMiwP9/sR88eJBly5bRs2dPHn30Ufr164fL5SptFxYWhs1mM7HSC8dms51w+xo1asTMmTPLLFu4cCE1a9Ys9xpq1qxJWFgYXl5e5b5ukepC4UZEgP//Ym/QoAEdO3bkmWeeYdGiRSxbtoxZs2aVtvvfozEOh4OHHnqI8PBw/Pz8aNKkCZMmTQKgSZMmAAwaNAiLxVL6PD4+ngEDBhAaGkrNmjXp3LkzK1euLFNLkyZNePnllxkxYgSBgYFccsklTJ06tUybI0eOMHToUOrUqUNAQACdOnXi559/Ln39u+++Izo6Gj8/P5o2bcoLL7xQJqSdjeHDhzN37lyKiopKl82YMYPhw4eXaXfw4EEsFgtz586le/fu+Pn5cfnllx93ZGfHjh3cdNNNBAUFERgYSI8ePYiPjz+n2kTkeAo3InJSvXr1ol27dixYsOCEr7/77rt8++23fPnll+zZs4fPPvusNMRs2bIFgJkzZ5KcnFz6PD8/nxtvvJGVK1cSExPDDTfcQP/+/UlMTCyz7smTJ9OpUydiYmJ48MEHGTVqFLt37y5dx9VXX83Ro0f59ttv2bZtG08++WTpKbQffviBu+++m0ceeYSdO3fy0UcfMWvWLP7zn/+cUz9ER0cTGRnJ119/DcDhw4f58ccfGTZs2AnbP/HEEzz++OPExMTQvXt3br75ZjIzMwFISkrib3/7G35+fqxevZqtW7cyYsSIcw5eInICF2xKThGpNIYPH24MGDDghK8NGTLEiIqKKn0OGAsXLjQMwzAefvhho1evXobH4znhe/+37am0atXKeO+990qfN27c2Lj77rtLn3s8HqN+/frGlClTDMMwjI8++sgIDAw0MjMzT7i+Hj16GC+//HKZZZ9++qkRHh5+0hpO1gd/bsPbb79t9OzZ0zAMw3jhhReMQYMGGVlZWQZgrFmzxjAMw0hISDAA45VXXil9v9PpNBo2bGi8+uqrhmEYxrhx44zIyEjD4XCcokdK+uCtt946ZRsROTEduRGRUzIMA4vFcsLX7r33XmJjY7nssst45JFHWL58+WnXV1BQwJNPPkmrVq2oVasWNWvWZPfu3ccduWnbtm3pzxaLhbCwMNLS0gCIjY2lQ4cO1KlT54S/Y+vWrUycOJGaNWuWPu6//36Sk5MpLCw8000v4+6772bTpk0cOHCAWbNmMWLEiJO27datW+nP3t7edOrUiV27dpXW3qNHD3x8fM6pDhE5PW+zCxCRim3Xrl1ERkae8LWOHTuSkJDAsmXLWLlyJbfffjvXXXcdX3311UnX98QTT/DDDz/wxhtv0KxZM/z9/bn11ltxOBxl2v31y99isZSedvL39z9lzR6PhxdeeIFbbrnluNf8/PxO+d6TqVu3Lv369ePvf/87xcXF9O3bl7y8vDN+/58B8XS1i8j505EbETmp1atXExcXx+DBg0/aJigoiCFDhjBt2jTmzZvH119/zbFjx4CSgOJ2u8u0X79+Pffeey+DBg2iTZs2hIWFcfDgwbOqq23btsTGxpb+nr/q2LEje/bsoVmzZsc9rNZz/9gbMWIEa9eu5Z577jnl3Uz/e9u4y+Vi69attGzZsrT29evX43Q6z7kOETk1HbkREaBk3JaUlBTcbjepqal8//33TJo0iX79+nHPPfec8D1vvfUW4eHhtG/fHqvVyvz58wkLC6NWrVpAyV1Pq1at4sorr8Rms1G7dm2aNWvGggUL6N+/PxaLhWefffa4sXRO54477uDll19m4MCBTJo0ifDwcGJiYoiIiKBbt24899xz9OvXj0aNGnHbbbdhtVr5/fffiYuL46WXXjrnPurTpw/p6ekEBQWdst37779P8+bNiYqK4q233iIrK6v0NNZDDz3Ee++9x9ChQxk3bhzBwcFs3ryZK664gssuu+ycaxOR/6cjNyICwPfff094eDhNmjShT58+rFmzhnfffZdFixad9ChFzZo1efXVV+nUqROdO3fm4MGDLF26tPToyOTJk1mxYgWNGjWiQ4cOQEkgql27Nt27d6d///7ccMMNdOzY8axq9fX1Zfny5dSvX58bb7yRNm3a8Morr5TWecMNN7B48WJWrFhB586d6dq1K2+++SaNGzc+jx4qObUUEhKCr6/vKdu98sorvPrqq7Rr147169ezaNEiQkJCgJLTW6tXry694ys6Oppp06bpGhyRcmQxDMMwuwgREbPde++9ZGdnn9eIygcPHiQyMpKYmBjat29/XvU0adKEMWPGMGbMmPNaj0h1pCM3IiJ/WLx4MTVr1mTx4sWm1fDyyy9Ts2bN4+4eE5EzpyM3IiJAWloaubm5AISHhxMQEHDW6yiPIzfHjh0rvVC6Xr16BAcHn9N6RKozhRsRERGpUnRaSkRERKoUhRsRERGpUhRuREREpEpRuBEREZEqReFGREREqhSFGxEREalSFG5ERESkSlG4ERERkSpF4UZERESqlP8DZ7f9KCORRbsAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fig = plt.figure()\n",
     "ax = fig.add_subplot(title=\"Perturbed Matter Component\", xlabel=\"Distance [Mpc]\", ylabel=\"z\")\n",
@@ -1015,206 +679,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mSignature:\u001b[0m\n",
-       "\u001b[0mz_at_value\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mfval\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mzmin\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m1e-08\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mzmax\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m1000\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mztol\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m1e-08\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mmaxfun\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m500\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mmethod\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Brent'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mbracket\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mverbose\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-       "\u001b[0;31mDocstring:\u001b[0m\n",
-       "Find the redshift ``z`` at which ``func(z) = fval``.\n",
-       "\n",
-       "This finds the redshift at which one of the cosmology functions or\n",
-       "methods (for example Planck13.distmod) is equal to a known value.\n",
-       "\n",
-       ".. warning::\n",
-       "  Make sure you understand the behavior of the function that you\n",
-       "  are trying to invert! Depending on the cosmology, there may not\n",
-       "  be a unique solution. For example, in the standard Lambda CDM\n",
-       "  cosmology, there are two redshifts which give an angular\n",
-       "  diameter distance of 1500 Mpc, z ~ 0.7 and z ~ 3.8. To force\n",
-       "  ``z_at_value`` to find the solution you are interested in, use the\n",
-       "  ``zmin`` and ``zmax`` keywords to limit the search range (see the\n",
-       "  example below).\n",
-       "\n",
-       "Parameters\n",
-       "----------\n",
-       "func : function or method\n",
-       "   A function that takes a redshift as input.\n",
-       "\n",
-       "fval : `~astropy.units.Quantity` instance\n",
-       "   The (scalar) value of ``func(z)`` to recover.\n",
-       "\n",
-       "zmin : float, optional\n",
-       "   The lower search limit for ``z``.  Beware of divergences\n",
-       "   in some cosmological functions, such as distance moduli,\n",
-       "   at z=0 (default 1e-8).\n",
-       "\n",
-       "zmax : float, optional\n",
-       "   The upper search limit for ``z`` (default 1000).\n",
-       "\n",
-       "ztol : float, optional\n",
-       "   The relative error in ``z`` acceptable for convergence.\n",
-       "\n",
-       "maxfun : int, optional\n",
-       "   The maximum number of function evaluations allowed in the\n",
-       "   optimization routine (default 500).\n",
-       "\n",
-       "method : str or callable, optional\n",
-       "   Type of solver to pass to the minimizer. The built-in options provided by\n",
-       "   :func:`~scipy.optimize.minimize_scalar` are 'Brent' (default), 'Golden' and\n",
-       "   'Bounded' with names case insensitive - see documentation there for details.\n",
-       "   It also accepts a custom solver by passing any user-provided callable object\n",
-       "   that meets the requirements listed therein under the Notes on\n",
-       "   \"Custom minimizers\" - or in more detail in :doc:`scipy:tutorial/optimize` -\n",
-       "   although their use is currently untested.\n",
-       "\n",
-       "   .. versionadded:: 4.3\n",
-       "\n",
-       "bracket : sequence, optional\n",
-       "   For methods 'Brent' and 'Golden', ``bracket`` defines the bracketing\n",
-       "   interval and can either have three items (z1, z2, z3) so that z1 < z2 < z3\n",
-       "   and ``func(z2) < func(z1), func(z3)`` or two items z1 and z3 which are\n",
-       "   assumed to be a starting interval for a downhill bracket search.\n",
-       "   For non-monotone functions such as angular diameter distance this may be\n",
-       "   used to start the search on the desired side of the maximum, but see\n",
-       "   Examples below for usage notes.\n",
-       "\n",
-       "   .. versionadded:: 4.3\n",
-       "\n",
-       "verbose : bool, optional\n",
-       "   Print diagnostic output from solver (default `False`).\n",
-       "\n",
-       "   .. versionadded:: 4.3\n",
-       "\n",
-       "\n",
-       "Returns\n",
-       "-------\n",
-       "z : float\n",
-       "  The redshift ``z`` satisfying ``zmin < z < zmax`` and ``func(z) =\n",
-       "  fval`` within ``ztol``.\n",
-       "\n",
-       "Notes\n",
-       "-----\n",
-       "This works for any arbitrary input cosmology, but is inefficient\n",
-       "if you want to invert a large number of values for the same\n",
-       "cosmology. In this case, it is faster to instead generate an array\n",
-       "of values at many closely-spaced redshifts that cover the relevant\n",
-       "redshift range, and then use interpolation to find the redshift at\n",
-       "each value you are interested in. For example, to efficiently find\n",
-       "the redshifts corresponding to 10^6 values of the distance modulus\n",
-       "in a Planck13 cosmology, you could do the following:\n",
-       "\n",
-       ">>> import astropy.units as u\n",
-       ">>> from astropy.cosmology import Planck13, z_at_value\n",
-       "\n",
-       "Generate 10^6 distance moduli between 24 and 44 for which we\n",
-       "want to find the corresponding redshifts:\n",
-       "\n",
-       ">>> Dvals = (24 + np.random.rand(1000000) * 20) * u.mag\n",
-       "\n",
-       "Make a grid of distance moduli covering the redshift range we\n",
-       "need using 50 equally log-spaced values between zmin and\n",
-       "zmax. We use log spacing to adequately sample the steep part of\n",
-       "the curve at low distance moduli:\n",
-       "\n",
-       ">>> zmin = z_at_value(Planck13.distmod, Dvals.min())\n",
-       ">>> zmax = z_at_value(Planck13.distmod, Dvals.max())\n",
-       ">>> zgrid = np.logspace(np.log10(zmin), np.log10(zmax), 50)\n",
-       ">>> Dgrid = Planck13.distmod(zgrid)\n",
-       "\n",
-       "Finally interpolate to find the redshift at each distance modulus:\n",
-       "\n",
-       ">>> zvals = np.interp(Dvals.value, Dgrid.value, zgrid)\n",
-       "\n",
-       "Examples\n",
-       "--------\n",
-       ">>> import astropy.units as u\n",
-       ">>> from astropy.cosmology import Planck13, Planck18, z_at_value\n",
-       "\n",
-       "The age and lookback time are monotonic with redshift, and so a\n",
-       "unique solution can be found:\n",
-       "\n",
-       ">>> z_at_value(Planck13.age, 2 * u.Gyr)                # doctest: +FLOAT_CMP\n",
-       "3.19812268\n",
-       "\n",
-       "The angular diameter is not monotonic however, and there are two\n",
-       "redshifts that give a value of 1500 Mpc. You can use the zmin and\n",
-       "zmax keywords to find the one you are interested in:\n",
-       "\n",
-       ">>> z_at_value(Planck18.angular_diameter_distance,\n",
-       "...            1500 * u.Mpc, zmax=1.5)                 # doctest: +FLOAT_CMP\n",
-       "0.68044452\n",
-       ">>> z_at_value(Planck18.angular_diameter_distance,\n",
-       "...            1500 * u.Mpc, zmin=2.5)                 # doctest: +FLOAT_CMP\n",
-       "3.7823268\n",
-       "\n",
-       "Alternatively the ``bracket`` option may be used to initialize the\n",
-       "function solver on a desired region, but one should be aware that this\n",
-       "does not guarantee it will remain close to this starting bracket.\n",
-       "For the example of angular diameter distance, which has a maximum near\n",
-       "a redshift of 1.6 in this cosmology, defining a bracket on either side\n",
-       "of this maximum will often return a solution on the same side:\n",
-       "\n",
-       ">>> z_at_value(Planck18.angular_diameter_distance,\n",
-       "...            1500 * u.Mpc, bracket=(1.0, 1.2))       # doctest: +FLOAT_CMP +IGNORE_WARNINGS\n",
-       "0.68044452\n",
-       "\n",
-       "But this is not ascertained especially if the bracket is chosen too wide\n",
-       "and/or too close to the turning point:\n",
-       "\n",
-       ">>> z_at_value(Planck18.angular_diameter_distance,\n",
-       "...            1500 * u.Mpc, bracket=(0.1, 1.5))       # doctest: +SKIP\n",
-       "3.7823268                                              # doctest: +SKIP\n",
-       "\n",
-       "Likewise, even for the same minimizer and same starting conditions different\n",
-       "results can be found depending on architecture or library versions:\n",
-       "\n",
-       ">>> z_at_value(Planck18.angular_diameter_distance,\n",
-       "...            1500 * u.Mpc, bracket=(2.0, 2.5))       # doctest: +SKIP\n",
-       "3.7823268                                              # doctest: +SKIP\n",
-       "\n",
-       ">>> z_at_value(Planck18.angular_diameter_distance,\n",
-       "...            1500 * u.Mpc, bracket=(2.0, 2.5))       # doctest: +SKIP\n",
-       "0.68044452                                             # doctest: +SKIP\n",
-       "\n",
-       "It is therefore generally safer to use the 3-parameter variant to ensure\n",
-       "the solution stays within the bracketing limits:\n",
-       "\n",
-       ">>> z_at_value(Planck18.angular_diameter_distance,\n",
-       "...            1500 * u.Mpc, bracket=(0.1, 1.0, 1.5))  # doctest: +FLOAT_CMP\n",
-       "0.68044452\n",
-       "\n",
-       "Also note that the luminosity distance and distance modulus (two\n",
-       "other commonly inverted quantities) are monotonic in flat and open\n",
-       "universes, but not in closed universes.\n",
-       "\u001b[0;31mFile:\u001b[0m      ~/local/astropy/astropy/cosmology/funcs.py\n",
-       "\u001b[0;31mType:\u001b[0m      function\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "z_at_value?"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "-"
@@ -1227,7 +701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1238,7 +712,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1252,7 +726,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.13"
   },
   "nteract": {
    "version": "0.28.0"

--- a/11-Cosmology/Astropy_Cosmology_Solutions.ipynb
+++ b/11-Cosmology/Astropy_Cosmology_Solutions.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,20 +66,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3386.845298737773"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "objective_function = lambda z: Planck18.Om(z) - (Planck18.Ogamma(z) + Planck18.Onu(z))\n",
     "zeq = z_at_value(objective_function, 0, zmin=2e3, zmax=1e4)\n",
@@ -96,66 +85,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.00029517286411294376"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Planck18.scale_factor(zeq)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$47605441 \\; \\mathrm{Mpc}$"
-      ],
-      "text/plain": [
-       "<Quantity 47605440.76948533 Mpc>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Planck18.luminosity_distance(zeq)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$63.388283 \\; \\mathrm{mag}$"
-      ],
-      "text/plain": [
-       "<Quantity 63.38828295 mag>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Planck18.distmod(zeq)"
    ]
@@ -164,7 +114,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -178,7 +128,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.13"
   },
   "nteract": {
    "version": "0.28.0"

--- a/12-ASDF/Solutions_intro_asdf.ipynb
+++ b/12-ASDF/Solutions_intro_asdf.ipynb
@@ -129,16 +129,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "jw['data'][0,0] = 900"
+    "# # Uncomment this to see the error:\n",
+    "# jw['data'][0,0] = 900"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d0375422",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -157,7 +150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
When I teach the OOP tutorial, I always mention that the `LightCurve` object created in the notebook is only meant for pedagogical purposes. I suggest that if you want to do real research with light curves, you would benefit greatly from using the `lightkurve` package.

In this PR, I put that commentary into text in the notebook.