### PR TITLE
Fix inconsistencies and hide warnings in Tables.ipynb

### DIFF
--- a/06-Tables/Tables.ipynb
+++ b/06-Tables/Tables.ipynb
@@ -68,7 +68,7 @@
     "from astropy.utils.exceptions import AstropyDeprecationWarning\n",
     "import numpy as np\n",
     "\n",
-    "%matplotlib inline \n",
+    "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "warnings.filterwarnings('ignore', category=AstropyDeprecationWarning, message=r'.*show_in_notebook.*')\n"
    ]
@@ -528,7 +528,7 @@
    },
    "outputs": [],
    "source": [
-    "Table.read('test.txt' ,format='ascii')  # note that the units and formatting of the original table are lost"
+    "Table.read('test.txt', format='ascii')  # note that the units and formatting of the original table are lost"
    ]
   },
   {
@@ -694,7 +694,7 @@
    "source": [
     "from astropy.table import QTable\n",
     "qts = QTable(ts)\n",
-    "qts['flux'] # but this one does - it *is* a Quantity"
+    "qts['flux']  # but this one does - it *is* a Quantity"
    ]
   },
   {
@@ -855,7 +855,7 @@
    },
    "outputs": [],
    "source": [
-    "t2 = Table([['x', 'y', 'z'], \n",
+    "t2 = Table([['x', 'y', 'z'],\n",
     "            [1.1, 2.2, 3.3]],\n",
     "           names=['name', 'value'],\n",
     "           masked=True)\n",

--- a/06-Tables/Tables.ipynb
+++ b/06-Tables/Tables.ipynb
@@ -63,12 +63,14 @@
    },
    "outputs": [],
    "source": [
+    "import warnings\n",
     "from astropy.table import Table\n",
-    "\n",
+    "from astropy.utils.exceptions import AstropyDeprecationWarning\n",
     "import numpy as np\n",
     "\n",
     "%matplotlib inline \n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "warnings.filterwarnings('ignore', category=AstropyDeprecationWarning, message=r'.*show_in_notebook.*')\n"
    ]
   },
   {
@@ -140,9 +142,9 @@
     "\n",
     "    >>> t\n",
     "    <Table rows=4 names=('name','flux')>\n",
-    "    array([('source 1', 1.2), ('source 2', 2.2), ('source 3', 3.1),\n",
-    "           ('source 4', 4.3)], \n",
-    "          dtype=[('name', 'S8'), ('flux', '<f8')])\n",
+    "    array([('larry', 1.2), ('curly', 2.2), ('moe', 3.1),\n",
+    "           ('shemp', 4.3)], \n",
+    "          dtype=[('name', '<U5'), ('flux', '<f8')])\n",
     "\n",
     "To get a plain view which is the same in notebook and terminal use `print()`:"
    ]
@@ -1240,7 +1242,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR fixes an inconsistency and some minor formatting errors. It also hides a deprecation warning thrown by the method `show_in_notebook()`.