### PR TITLE
Bugfixes for data downloads in specutils analysis notebooks

### DIFF
--- a/00-Install_and_Setup/requirements.txt
+++ b/00-Install_and_Setup/requirements.txt
@@ -24,6 +24,6 @@ asdf
 asdf-astropy
 gwcs>=0.20
 photutils>=1.10.0
-specutils>=1.12.0
+specutils>=1.18.0
 astroquery>=0.4.7dev9008
 openpyxl

--- a/09b-Specutils/Specutils_analysis.ipynb
+++ b/09b-Specutils/Specutils_analysis.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "## Sample Spectrum and SNR\n",
     "\n",
-    "For use below, we also load the sample SDSS spectrum downloaded in the [overview notebook](Specutils_overview.ipynb).  See that notebook if you have not yet downloaded this spectrum."
+    "For use below, we also load the sample SDSS spectrum downloaded in the [overview notebook](Specutils_overview.ipynb)."
    ]
   },
   {
@@ -71,7 +71,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sdss_spec = Spectrum1D.read('data/sdss_spectrum.fits', format='SDSS-III/IV spec')\n",
+    "from urllib.request import urlretrieve\n",
+    "\n",
+    "sdss_spectrum_path = 'data/sdss_spectrum.fits'\n",
+    "\n",
+    "url = 'https://data.sdss.org/sas/dr16/sdss/spectro/redux/26/spectra/1323/spec-1323-52797-0012.fits'\n",
+    "urlretrieve(url, sdss_spectrum_path)\n",
+    "\n",
+    "sdss_spec = Spectrum1D.read(sdss_spectrum_path, format='SDSS-III/IV spec')\n",
     "plt.step(sdss_spec.wavelength, sdss_spec.flux);"
    ]
   },
@@ -660,7 +667,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -674,7 +681,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.11.5"
   },
   "toc": {
    "base_numbering": 1,
@@ -691,5 +698,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/09b-Specutils/Specutils_analysis_solutions.ipynb
+++ b/09b-Specutils/Specutils_analysis_solutions.ipynb
@@ -71,7 +71,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sdss_spec = Spectrum1D.read('data/sdss_spectrum.fits', format='SDSS-III/IV spec')\n",
+    "from urllib.request import urlretrieve\n",
+    "\n",
+    "sdss_spectrum_path = 'data/sdss_spectrum.fits'\n",
+    "\n",
+    "url = 'https://data.sdss.org/sas/dr16/sdss/spectro/redux/26/spectra/1323/spec-1323-52797-0012.fits'\n",
+    "urlretrieve(url, sdss_spectrum_path)\n",
+    "\n",
+    "sdss_spec = Spectrum1D.read(sdss_spectrum_path, format='SDSS-III/IV spec')\n",
     "plt.step(sdss_spec.wavelength, sdss_spec.flux);"
    ]
   },
@@ -850,6 +857,13 @@
     "# huzzah!  the fit gives a pretty close answer given the noise\n",
     "gmodel, full_spec_model.left"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -868,7 +882,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.5"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
CI is currently failing on both specutils analysis notebooks because a data file is assumed to exist when it does not. I've added lines to ensure that the necessary file download happens no matter when a given notebook runs.