### PR TITLE
ALOHA 2024: Update env YAML

### DIFF
--- a/00-Install_and_Setup/environment.yml
+++ b/00-Install_and_Setup/environment.yml
@@ -1,6 +1,5 @@
-name: astropy-env
+name: astropy-aloha-2024
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
-  - astroscrappy
+  - python=3.12


### PR DESCRIPTION
Why do we need astroscrappy? 

While I would prefer Python 3.13, some stuff not caught up yet (cough, jdaviz, cough), so Python 3.12 is better.