### PR TITLE
bugfix: world_to_pix in gwcs via SpectralCoords

### DIFF
--- a/09b-Specutils/Specutils_overview.ipynb
+++ b/09b-Specutils/Specutils_overview.ipynb
@@ -55,6 +55,7 @@
     "import numpy as np\n",
     "\n",
     "import astropy.units as u\n",
+    "from astropy.coordinates import SpectralCoord\n",
     "\n",
     "import specutils\n",
     "from specutils import Spectrum1D\n",
@@ -217,7 +218,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spec1d.wcs.world_to_pixel([400, 450]*u.nm)"
+    "spec1d.wcs.world_to_pixel(SpectralCoord([400, 450]*u.nm))"
    ]
   },
   {
@@ -454,7 +455,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -468,9 +469,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/09b-Specutils/Specutils_overview_solutions.ipynb
+++ b/09b-Specutils/Specutils_overview_solutions.ipynb
@@ -55,6 +55,7 @@
     "import numpy as np\n",
     "\n",
     "import astropy.units as u\n",
+    "from astropy.coordinates import SpectralCoord\n",
     "\n",
     "import specutils\n",
     "from specutils import Spectrum1D\n",
@@ -217,7 +218,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spec1d.wcs.world_to_pixel([400, 450]*u.nm)"
+    "spec1d.wcs.world_to_pixel(SpectralCoord([400, 450]*u.nm))"
    ]
   },
   {
@@ -599,7 +600,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
CI currently fails because GWCS expects `world_to_pixel` transformations of 1D spectral coordinates using the astropy `SpectralCoords`, rather than a `Quantity`.