### PR TITLE
Updates to photutils notebooks

### DIFF
--- a/09-Photutils/01-aperture_basics.ipynb
+++ b/09-Photutils/01-aperture_basics.ipynb
@@ -720,6 +720,39 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Including Sky Coordinates in the output table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The output table will include the sky coordinates of the input x/y positions if we pass in the `WCS` transform defined when we loaded the data. Note that this requires photutils version >= 2.1.0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phot = aperture_photometry(data << unit, apertures, error=total_error << unit, wcs=wcs)\n",
+    "phot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phot['sky_center']  # a SkyCoord object"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "slideshow": {
      "slide_type": "slide"
@@ -777,41 +810,6 @@
     "\n",
     "phot['f160w_abmag'] = abmag\n",
     "phot"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Using the `WCS` transform defined when we loaded the data, we can also calculate the sky coordinates for these objects and add them to the table."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# convert pixel positions to sky coordinates\n",
-    "x, y = np.transpose(positions)\n",
-    "sky_coord = wcs.pixel_to_world(x, y)  # a SkyCoord object\n",
-    "\n",
-    "# we can add the astropy SkyCoord object directly to the table\n",
-    "phot['sky_center'] = sky_coord\n",
-    "phot"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "phot['sky_center']  # a SkyCoord object"
    ]
   },
   {
@@ -1195,7 +1193,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,

--- a/09-Photutils/05-psf_photometry.ipynb
+++ b/09-Photutils/05-psf_photometry.ipynb
@@ -152,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "noise = make_noise_image(data.shape, mean=0, stddev=0.1)\n",
+    "noise = make_noise_image(data.shape, mean=0, stddev=0.1, seed=0)\n",
     "data += noise\n",
     "error = np.abs(noise)\n",
     "plt.figure(figsize=(5, 5))\n",


### PR DESCRIPTION
This PR:

* Adds a seed to the noise image for reproducibility in the PSF photometry notebook
* Updates the aperture notebook to show sky coordinates when a WCS is passed to `aperture_photometry` (requires 2.1.0+)

Closes #268.